### PR TITLE
Resolved issue with incorrect screen being navigated to when app is relaunched from background

### DIFF
--- a/app/src/main/java/com/theupnextapp/MainActivity.kt
+++ b/app/src/main/java/com/theupnextapp/MainActivity.kt
@@ -99,7 +99,7 @@ class MainActivity : AppCompatActivity(), TabConnectionCallback {
 
         setupActionBarWithNavController(navController, appBarConfiguration)
         bottomNavigationView?.setupWithNavController(navController)
-        bottomNavigationView?.setOnItemReselectedListener {  }
+        bottomNavigationView?.setOnItemReselectedListener { }
     }
 
     override fun onSupportNavigateUp(): Boolean {
@@ -154,8 +154,10 @@ class MainActivity : AppCompatActivity(), TabConnectionCallback {
         val code = intent?.data?.getQueryParameter("code")
         val traktConnectionArg = TraktConnectionArg(code)
 
-        val bundle = bundleOf(EXTRA_TRAKT_URI to traktConnectionArg)
-        navController.navigate(R.id.traktAccountFragment, bundle)
+        if (!code.isNullOrEmpty()) {
+            val bundle = bundleOf(EXTRA_TRAKT_URI to traktConnectionArg)
+            navController.navigate(R.id.traktAccountFragment, bundle)
+        }
     }
 
     fun hideBottomNavigation() {


### PR DESCRIPTION
The issue was a result of `onNewIntent` which is triggered when the app returns from the background. At this point, the code query parameter is null, however, as there was no null check the account screen was navigated to. I have added the necessary null check

Closes #30 