### PR TITLE
Upgraded to Material Design 3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -113,8 +113,6 @@ dependencies {
     implementation "androidx.hilt:hilt-navigation-compose:$compose_hilt_navigation_version"
     // Compose Livedata runtime
     implementation "androidx.compose.runtime:runtime-livedata:$compose_ui_version"
-    // When using a MDC theme
-    implementation "com.google.android.material:compose-theme-adapter:$compose_theme_adapter_version"
 
     // Coroutines for getting off the UI thread
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlin_coroutines_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -99,7 +99,8 @@ dependencies {
     // Integration with activities
     implementation "androidx.activity:activity-compose:$compose_activity_version"
     // Compose Material Design
-    implementation "androidx.compose.material:material:$compose_material_version"
+    implementation "androidx.compose.material3:material3:$compose_material_version"
+    implementation "androidx.compose.material3:material3-window-size-class:$compose_material_version"
     // Animations
     implementation "androidx.compose.animation:animation:$compose_animation_version"
     // Tooling support (Previews, etc.)

--- a/app/src/main/java/com/theupnextapp/ui/components/Text.kt
+++ b/app/src/main/java/com/theupnextapp/ui/components/Text.kt
@@ -22,8 +22,8 @@
 package com.theupnextapp.ui.components
 
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -43,7 +43,7 @@ fun PosterAttributionItem() {
             end = 4.dp
         ),
         maxLines = 5,
-        style = MaterialTheme.typography.caption
+        style = MaterialTheme.typography.labelMedium
     )
 }
 
@@ -52,7 +52,7 @@ fun PosterTitleTextItem(title: String) {
     Text(
         text = title,
         fontWeight = FontWeight.Bold,
-        style = MaterialTheme.typography.caption,
+        style = MaterialTheme.typography.labelMedium,
         maxLines = 1,
         modifier = Modifier.padding(
             start = 4.dp,
@@ -77,7 +77,7 @@ fun SectionHeadingText(
                 end = 16.dp,
                 bottom = 4.dp
             ),
-        style = MaterialTheme.typography.h5,
+        style = MaterialTheme.typography.headlineMedium,
         fontWeight = FontWeight.Bold
     )
 }

--- a/app/src/main/java/com/theupnextapp/ui/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/com/theupnextapp/ui/dashboard/DashboardFragment.kt
@@ -20,7 +20,7 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.composethemeadapter.MdcTheme
@@ -32,7 +32,7 @@ import com.theupnextapp.ui.common.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
-@ExperimentalMaterialApi
+@ExperimentalMaterial3Api
 @AndroidEntryPoint
 class DashboardFragment : BaseFragment() {
 

--- a/app/src/main/java/com/theupnextapp/ui/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/com/theupnextapp/ui/dashboard/DashboardFragment.kt
@@ -23,12 +23,12 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import com.google.android.material.composethemeadapter.MdcTheme
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.theupnextapp.R
 import com.theupnextapp.databinding.FragmentDashboardBinding
 import com.theupnextapp.domain.ShowDetailArg
 import com.theupnextapp.ui.common.BaseFragment
+import com.theupnextapp.ui.theme.UpnextTheme
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -60,7 +60,7 @@ class DashboardFragment : BaseFragment() {
 
         binding.composeContainer.apply {
             setContent {
-                MdcTheme {
+                UpnextTheme {
                     DashboardScreen {
                         val direction =
                             DashboardFragmentDirections.actionDashboardFragmentToShowDetailFragment(

--- a/app/src/main/java/com/theupnextapp/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/theupnextapp/ui/dashboard/DashboardScreen.kt
@@ -30,9 +30,9 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.LinearProgressIndicator
-import androidx.compose.material.Surface
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
@@ -44,7 +44,7 @@ import com.theupnextapp.domain.ScheduleShow
 import com.theupnextapp.ui.components.SectionHeadingText
 import com.theupnextapp.ui.widgets.ListPosterCard
 
-@ExperimentalMaterialApi
+@ExperimentalMaterial3Api
 @Composable
 fun DashboardScreen(
     viewModel: DashboardViewModel = hiltViewModel(),
@@ -114,7 +114,7 @@ fun DashboardScreen(
 
 }
 
-@ExperimentalMaterialApi
+@ExperimentalMaterial3Api
 @Composable
 fun ShowsRow(
     list: List<ScheduleShow>,

--- a/app/src/main/java/com/theupnextapp/ui/explore/ExploreFragment.kt
+++ b/app/src/main/java/com/theupnextapp/ui/explore/ExploreFragment.kt
@@ -25,7 +25,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.findNavController
@@ -37,7 +37,7 @@ import com.theupnextapp.ui.common.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
-@ExperimentalMaterialApi
+@ExperimentalMaterial3Api
 @AndroidEntryPoint
 class ExploreFragment : BaseFragment() {
 

--- a/app/src/main/java/com/theupnextapp/ui/explore/ExploreFragment.kt
+++ b/app/src/main/java/com/theupnextapp/ui/explore/ExploreFragment.kt
@@ -29,11 +29,11 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.findNavController
-import com.google.android.material.composethemeadapter.MdcTheme
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.theupnextapp.databinding.FragmentExploreBinding
 import com.theupnextapp.domain.ShowDetailArg
 import com.theupnextapp.ui.common.BaseFragment
+import com.theupnextapp.ui.theme.UpnextTheme
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -61,7 +61,7 @@ class ExploreFragment : BaseFragment() {
         binding.composeContainer.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
-                MdcTheme {
+                UpnextTheme {
                     ExploreScreen(
                         onPopularShowClick = {
                             val directions =

--- a/app/src/main/java/com/theupnextapp/ui/explore/ExploreScreen.kt
+++ b/app/src/main/java/com/theupnextapp/ui/explore/ExploreScreen.kt
@@ -30,9 +30,9 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.LinearProgressIndicator
-import androidx.compose.material.Surface
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
@@ -46,7 +46,7 @@ import com.theupnextapp.domain.TraktTrendingShows
 import com.theupnextapp.ui.components.SectionHeadingText
 import com.theupnextapp.ui.widgets.ListPosterCard
 
-@ExperimentalMaterialApi
+@ExperimentalMaterial3Api
 @Composable
 fun ExploreScreen(
     viewModel: ExploreViewModel = hiltViewModel(),
@@ -117,7 +117,7 @@ fun ExploreScreen(
     }
 }
 
-@ExperimentalMaterialApi
+@ExperimentalMaterial3Api
 @Composable
 fun TrendingShowsRow(
     list: List<TraktTrendingShows>,
@@ -140,7 +140,7 @@ fun TrendingShowsRow(
     }
 }
 
-@ExperimentalMaterialApi
+@ExperimentalMaterial3Api
 @Composable
 fun PopularShowsRow(
     list: List<TraktPopularShows>,
@@ -163,7 +163,7 @@ fun PopularShowsRow(
     }
 }
 
-@ExperimentalMaterialApi
+@ExperimentalMaterial3Api
 @Composable
 fun MostAnticipatedShowsRow(
     list: List<TraktMostAnticipated>,

--- a/app/src/main/java/com/theupnextapp/ui/search/SearchFragment.kt
+++ b/app/src/main/java/com/theupnextapp/ui/search/SearchFragment.kt
@@ -26,7 +26,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.navigation.fragment.findNavController
@@ -37,6 +37,8 @@ import com.theupnextapp.databinding.FragmentSearchBinding
 import com.theupnextapp.ui.common.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 
+@ExperimentalMaterial3Api
+@ExperimentalComposeUiApi
 @AndroidEntryPoint
 class SearchFragment : BaseFragment() {
 
@@ -48,7 +50,6 @@ class SearchFragment : BaseFragment() {
         setHasOptionsMenu(true)
     }
 
-    @OptIn(ExperimentalMaterialApi::class, ExperimentalComposeUiApi::class)
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,

--- a/app/src/main/java/com/theupnextapp/ui/search/SearchFragment.kt
+++ b/app/src/main/java/com/theupnextapp/ui/search/SearchFragment.kt
@@ -30,11 +30,11 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.navigation.fragment.findNavController
-import com.google.android.material.composethemeadapter.MdcTheme
 import com.theupnextapp.MainActivity
 import com.theupnextapp.R
 import com.theupnextapp.databinding.FragmentSearchBinding
 import com.theupnextapp.ui.common.BaseFragment
+import com.theupnextapp.ui.theme.UpnextTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @ExperimentalMaterial3Api
@@ -62,7 +62,7 @@ class SearchFragment : BaseFragment() {
         binding.composeContainer.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
-                MdcTheme {
+                UpnextTheme {
                     SearchScreen(navController = findNavController())
                 }
             }

--- a/app/src/main/java/com/theupnextapp/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/theupnextapp/ui/search/SearchScreen.kt
@@ -28,11 +28,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.LinearProgressIndicator
-import androidx.compose.material.OutlinedTextField
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.livedata.observeAsState
@@ -49,7 +49,7 @@ import com.theupnextapp.domain.ShowDetailArg
 import com.theupnextapp.domain.ShowSearch
 import com.theupnextapp.ui.widgets.SearchListCard
 
-@ExperimentalMaterialApi
+@ExperimentalMaterial3Api
 @ExperimentalComposeUiApi
 @Composable
 fun SearchScreen(
@@ -98,7 +98,7 @@ fun SearchScreen(
 }
 
 @ExperimentalComposeUiApi
-@ExperimentalMaterialApi
+@ExperimentalMaterial3Api
 @Composable
 fun SearchArea(
     searchResultsList: List<ShowSearch>?,
@@ -155,7 +155,7 @@ fun SearchInputField(
     )
 }
 
-@ExperimentalMaterialApi
+@ExperimentalMaterial3Api
 @Composable
 fun SearchResultsList(
     list: List<ShowSearch>,

--- a/app/src/main/java/com/theupnextapp/ui/showDetail/ShowDetailFragment.kt
+++ b/app/src/main/java/com/theupnextapp/ui/showDetail/ShowDetailFragment.kt
@@ -31,12 +31,12 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
-import com.google.android.material.composethemeadapter.MdcTheme
 import com.theupnextapp.MainActivity
 import com.theupnextapp.R
 import com.theupnextapp.databinding.FragmentShowDetailBinding
 import com.theupnextapp.domain.ShowDetailArg
 import com.theupnextapp.ui.common.BaseFragment
+import com.theupnextapp.ui.theme.UpnextTheme
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -87,7 +87,7 @@ class ShowDetailFragment : BaseFragment() {
             // https://developer.android.com/jetpack/compose/interop/interop-apis
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
-                MdcTheme {
+                UpnextTheme {
                     ShowDetailScreen(
                         onSeasonsClick = {
                             viewModel.onSeasonsClick()

--- a/app/src/main/java/com/theupnextapp/ui/showDetail/ShowDetailScreen.kt
+++ b/app/src/main/java/com/theupnextapp/ui/showDetail/ShowDetailScreen.kt
@@ -36,12 +36,12 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Button
-import androidx.compose.material.LinearProgressIndicator
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.OutlinedButton
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.material3.Button
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
@@ -161,7 +161,7 @@ fun DetailArea(
                         top = 4.dp,
                         end = 16.dp,
                     ),
-                style = MaterialTheme.typography.body2
+                style = MaterialTheme.typography.bodyMedium
             )
         }
 
@@ -220,7 +220,7 @@ fun BackdropAndTitle(showDetailArgs: ShowDetailArg?, showSummary: ShowDetailSumm
     showSummary?.name?.let { name ->
         Text(
             text = name,
-            style = MaterialTheme.typography.h5,
+            style = MaterialTheme.typography.headlineMedium,
             fontWeight = FontWeight.Bold,
             modifier = Modifier
                 .fillMaxWidth()
@@ -235,7 +235,7 @@ fun BackdropAndTitle(showDetailArgs: ShowDetailArg?, showSummary: ShowDetailSumm
     showSummary?.status?.let { status ->
         Text(
             text = status,
-            style = MaterialTheme.typography.caption,
+            style = MaterialTheme.typography.labelMedium,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(
@@ -293,7 +293,7 @@ fun PosterAndMetadata(showSummary: ShowDetailSummary?) {
 
             Text(
                 text = stringResource(id = R.string.tv_maze_creative_commons_attribution_text_multiple),
-                style = MaterialTheme.typography.caption,
+                style = MaterialTheme.typography.labelMedium,
                 modifier = Modifier.padding(8.dp)
             )
         }
@@ -414,7 +414,7 @@ fun ShowCast(
         item.name?.let { name ->
             Text(
                 text = name,
-                style = MaterialTheme.typography.body1,
+                style = MaterialTheme.typography.bodyLarge,
                 modifier = Modifier
                     .fillMaxWidth()
                     .align(Alignment.CenterHorizontally)
@@ -424,7 +424,7 @@ fun ShowCast(
         item.characterName?.let { characterName ->
             Text(
                 text = characterName,
-                style = MaterialTheme.typography.caption,
+                style = MaterialTheme.typography.labelMedium,
                 fontWeight = FontWeight.Thin,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -454,7 +454,7 @@ fun PreviousEpisode(showPreviousEpisode: ShowPreviousEpisode) {
                     end = 16.dp,
                     bottom = 4.dp
                 ),
-            style = MaterialTheme.typography.caption
+            style = MaterialTheme.typography.labelMedium
         )
 
         showPreviousEpisode.previousEpisodeSummary?.let {
@@ -483,7 +483,7 @@ fun NextEpisode(showNextEpisode: ShowNextEpisode) {
                     end = 16.dp,
                     bottom = 4.dp
                 ),
-            style = MaterialTheme.typography.caption
+            style = MaterialTheme.typography.labelMedium
         )
 
         showNextEpisode.nextEpisodeSummary?.let {
@@ -504,7 +504,7 @@ fun EpisodeSummary(summary: String) {
                 bottom = 8.dp
             )
             .fillMaxWidth(),
-        style = MaterialTheme.typography.body2
+        style = MaterialTheme.typography.bodyMedium
     )
 }
 
@@ -531,7 +531,7 @@ private fun TraktRatingSummary(ratingData: TraktShowRating) {
                         id = R.string.show_detail_rating_numerator,
                         ratingData.rating.toString()
                     ),
-                    style = MaterialTheme.typography.h3
+                    style = MaterialTheme.typography.headlineSmall
                 )
 
                 Text(
@@ -539,7 +539,7 @@ private fun TraktRatingSummary(ratingData: TraktShowRating) {
                         R.string.show_detail_rating_votes,
                         ratingData.votes.toString()
                     ),
-                    style = MaterialTheme.typography.caption
+                    style = MaterialTheme.typography.labelMedium
                 )
             }
 
@@ -607,8 +607,8 @@ fun LinearProgressPreview() {
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.padding(8.dp)
         ) {
-            Text(text = "7.0", style = MaterialTheme.typography.h4)
-            Text(text = "618 votes", style = MaterialTheme.typography.caption)
+            Text(text = "7.0", style = MaterialTheme.typography.headlineSmall)
+            Text(text = "618 votes", style = MaterialTheme.typography.labelMedium)
         }
 
         Column(
@@ -670,12 +670,12 @@ fun HeadingAndItemText(
         Text(
             text = heading.uppercase(),
             fontWeight = FontWeight.Bold,
-            style = MaterialTheme.typography.caption
+            style = MaterialTheme.typography.labelMedium
         )
 
         Text(
             text = item,
-            style = MaterialTheme.typography.body2
+            style = MaterialTheme.typography.bodyMedium
         )
     }
 }

--- a/app/src/main/java/com/theupnextapp/ui/showDetail/ShowDetailScreen.kt
+++ b/app/src/main/java/com/theupnextapp/ui/showDetail/ShowDetailScreen.kt
@@ -670,12 +670,12 @@ fun HeadingAndItemText(
         Text(
             text = heading.uppercase(),
             fontWeight = FontWeight.Bold,
-            style = MaterialTheme.typography.labelMedium
+            style = MaterialTheme.typography.bodyMedium
         )
 
         Text(
             text = item,
-            style = MaterialTheme.typography.bodyMedium
+            style = MaterialTheme.typography.bodySmall
         )
     }
 }

--- a/app/src/main/java/com/theupnextapp/ui/showSeasonEpisodes/ShowSeasonEpisodesFragment.kt
+++ b/app/src/main/java/com/theupnextapp/ui/showSeasonEpisodes/ShowSeasonEpisodesFragment.kt
@@ -25,7 +25,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.navArgs
@@ -39,6 +39,7 @@ import com.theupnextapp.ui.common.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
+@ExperimentalMaterial3Api
 @AndroidEntryPoint
 class ShowSeasonEpisodesFragment : BaseFragment() {
 
@@ -54,7 +55,6 @@ class ShowSeasonEpisodesFragment : BaseFragment() {
         showSeasonEpisodesViewModelFactory.create(this, args.showSeasonEpisode)
     }
 
-    @OptIn(ExperimentalMaterialApi::class)
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?

--- a/app/src/main/java/com/theupnextapp/ui/showSeasonEpisodes/ShowSeasonEpisodesFragment.kt
+++ b/app/src/main/java/com/theupnextapp/ui/showSeasonEpisodes/ShowSeasonEpisodesFragment.kt
@@ -29,13 +29,13 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.navArgs
-import com.google.android.material.composethemeadapter.MdcTheme
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.theupnextapp.MainActivity
 import com.theupnextapp.R
 import com.theupnextapp.databinding.FragmentShowSeasonEpisodesBinding
 import com.theupnextapp.ui.common.BaseFragment
+import com.theupnextapp.ui.theme.UpnextTheme
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -66,7 +66,7 @@ class ShowSeasonEpisodesFragment : BaseFragment() {
         binding.composeContainer.apply {
             setContent {
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-                MdcTheme {
+                UpnextTheme {
                     ShowSeasonEpisodesScreen(viewModel = viewModel)
                 }
             }

--- a/app/src/main/java/com/theupnextapp/ui/showSeasonEpisodes/ShowSeasonEpisodesScreen.kt
+++ b/app/src/main/java/com/theupnextapp/ui/showSeasonEpisodes/ShowSeasonEpisodesScreen.kt
@@ -145,7 +145,8 @@ fun ShowSeasonEpisodeCard(
                             item.number.toString()
                         ),
                         modifier = Modifier.padding(4.dp),
-                        style = MaterialTheme.typography.headlineMedium
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Bold
                     )
                 }
 
@@ -156,7 +157,7 @@ fun ShowSeasonEpisodeCard(
                             modifier = Modifier
                                 .padding(start = 4.dp)
                                 .fillMaxWidth(),
-                            style = MaterialTheme.typography.labelMedium,
+                            style = MaterialTheme.typography.bodyMedium,
                             fontWeight = FontWeight.Bold
                         )
                     }
@@ -173,7 +174,7 @@ fun ShowSeasonEpisodeCard(
                                     bottom = 2.dp
                                 )
                                 .fillMaxWidth(),
-                            style = MaterialTheme.typography.labelMedium
+                            style = MaterialTheme.typography.bodySmall
                         )
                     }
                 }
@@ -188,7 +189,7 @@ fun ShowSeasonEpisodeCard(
                         modifier = Modifier
                             .padding(4.dp)
                             .fillMaxWidth(),
-                        style = MaterialTheme.typography.labelMedium
+                        style = MaterialTheme.typography.bodySmall
                     )
                 }
             }

--- a/app/src/main/java/com/theupnextapp/ui/showSeasonEpisodes/ShowSeasonEpisodesScreen.kt
+++ b/app/src/main/java/com/theupnextapp/ui/showSeasonEpisodes/ShowSeasonEpisodesScreen.kt
@@ -30,12 +30,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.Card
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.LinearProgressIndicator
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
@@ -51,7 +51,7 @@ import com.theupnextapp.ui.components.PosterImage
 import com.theupnextapp.ui.components.SectionHeadingText
 import org.jsoup.Jsoup
 
-@ExperimentalMaterialApi
+@ExperimentalMaterial3Api
 @Composable
 fun ShowSeasonEpisodesScreen(
     viewModel: ShowSeasonEpisodesViewModel
@@ -86,7 +86,7 @@ fun ShowSeasonEpisodesScreen(
     }
 }
 
-@ExperimentalMaterialApi
+@ExperimentalMaterial3Api
 @Composable
 fun ShowSeasonEpisodes(
     seasonNumber: Int,
@@ -108,13 +108,12 @@ fun ShowSeasonEpisodes(
     }
 }
 
-@ExperimentalMaterialApi
+@ExperimentalMaterial3Api
 @Composable
 fun ShowSeasonEpisodeCard(
     item: ShowSeasonEpisode
 ) {
     Card(
-        elevation = 4.dp,
         shape = MaterialTheme.shapes.large,
         modifier = Modifier
             .fillMaxWidth()
@@ -146,7 +145,7 @@ fun ShowSeasonEpisodeCard(
                             item.number.toString()
                         ),
                         modifier = Modifier.padding(4.dp),
-                        style = MaterialTheme.typography.h6
+                        style = MaterialTheme.typography.headlineMedium
                     )
                 }
 
@@ -157,7 +156,7 @@ fun ShowSeasonEpisodeCard(
                             modifier = Modifier
                                 .padding(start = 4.dp)
                                 .fillMaxWidth(),
-                            style = MaterialTheme.typography.caption,
+                            style = MaterialTheme.typography.labelMedium,
                             fontWeight = FontWeight.Bold
                         )
                     }
@@ -174,7 +173,7 @@ fun ShowSeasonEpisodeCard(
                                     bottom = 2.dp
                                 )
                                 .fillMaxWidth(),
-                            style = MaterialTheme.typography.caption
+                            style = MaterialTheme.typography.labelMedium
                         )
                     }
                 }
@@ -189,7 +188,7 @@ fun ShowSeasonEpisodeCard(
                         modifier = Modifier
                             .padding(4.dp)
                             .fillMaxWidth(),
-                        style = MaterialTheme.typography.caption
+                        style = MaterialTheme.typography.labelMedium
                     )
                 }
             }

--- a/app/src/main/java/com/theupnextapp/ui/showSeasons/ShowSeasonsFragment.kt
+++ b/app/src/main/java/com/theupnextapp/ui/showSeasons/ShowSeasonsFragment.kt
@@ -30,11 +30,11 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
-import com.google.android.material.composethemeadapter.MdcTheme
 import com.theupnextapp.MainActivity
 import com.theupnextapp.databinding.FragmentShowSeasonsBinding
 import com.theupnextapp.domain.ShowSeasonEpisodesArg
 import com.theupnextapp.ui.common.BaseFragment
+import com.theupnextapp.ui.theme.UpnextTheme
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -65,7 +65,7 @@ class ShowSeasonsFragment : BaseFragment() {
         binding.composeContainer.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
-                MdcTheme {
+                UpnextTheme {
                     ShowSeasonsScreen(viewModel = viewModel) {
                         val directions =
                             ShowSeasonsFragmentDirections.actionShowSeasonsFragmentToShowSeasonEpisodesFragment(

--- a/app/src/main/java/com/theupnextapp/ui/showSeasons/ShowSeasonsFragment.kt
+++ b/app/src/main/java/com/theupnextapp/ui/showSeasons/ShowSeasonsFragment.kt
@@ -25,7 +25,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -38,7 +38,7 @@ import com.theupnextapp.ui.common.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
-@ExperimentalMaterialApi
+@ExperimentalMaterial3Api
 @AndroidEntryPoint
 class ShowSeasonsFragment : BaseFragment() {
 

--- a/app/src/main/java/com/theupnextapp/ui/showSeasons/ShowSeasonsScreen.kt
+++ b/app/src/main/java/com/theupnextapp/ui/showSeasons/ShowSeasonsScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.theupnextapp.R
 import com.theupnextapp.domain.ShowSeason
@@ -132,7 +133,8 @@ fun ShowSeasonCard(
                             item.seasonNumber.toString()
                         ),
                         modifier = Modifier.padding(4.dp),
-                        style = MaterialTheme.typography.headlineMedium
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Bold
                     )
                 }
 
@@ -143,7 +145,7 @@ fun ShowSeasonCard(
                             item.premiereDate
                         ),
                         modifier = Modifier.padding(2.dp),
-                        style = MaterialTheme.typography.labelMedium
+                        style = MaterialTheme.typography.bodyMedium
                     )
                 }
 
@@ -154,7 +156,7 @@ fun ShowSeasonCard(
                             item.endDate
                         ),
                         modifier = Modifier.padding(2.dp),
-                        style = MaterialTheme.typography.labelMedium
+                        style = MaterialTheme.typography.bodyMedium
                     )
                 }
 
@@ -169,7 +171,7 @@ fun ShowSeasonCard(
                             bottom = 2.dp,
                             end = 4.dp
                         ),
-                        style = MaterialTheme.typography.labelMedium
+                        style = MaterialTheme.typography.bodyMedium
                     )
                 }
             }

--- a/app/src/main/java/com/theupnextapp/ui/showSeasons/ShowSeasonsScreen.kt
+++ b/app/src/main/java/com/theupnextapp/ui/showSeasons/ShowSeasonsScreen.kt
@@ -32,12 +32,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.Card
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.LinearProgressIndicator
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
@@ -50,7 +50,7 @@ import com.theupnextapp.domain.ShowSeason
 import com.theupnextapp.ui.components.PosterImage
 import com.theupnextapp.ui.components.SectionHeadingText
 
-@ExperimentalMaterialApi
+@ExperimentalMaterial3Api
 @Composable
 fun ShowSeasonsScreen(
     viewModel: ShowSeasonsViewModel,
@@ -81,7 +81,7 @@ fun ShowSeasonsScreen(
     }
 }
 
-@ExperimentalMaterialApi
+@ExperimentalMaterial3Api
 @Composable
 fun ShowSeasons(list: List<ShowSeason>, onClick: (item: ShowSeason) -> Unit) {
     Column(modifier = Modifier.fillMaxWidth()) {
@@ -98,14 +98,13 @@ fun ShowSeasons(list: List<ShowSeason>, onClick: (item: ShowSeason) -> Unit) {
     }
 }
 
-@ExperimentalMaterialApi
+@ExperimentalMaterial3Api
 @Composable
 fun ShowSeasonCard(
     item: ShowSeason,
     onClick: () -> Unit
 ) {
     Card(
-        elevation = 4.dp,
         shape = MaterialTheme.shapes.large,
         modifier = Modifier
             .fillMaxWidth()
@@ -133,7 +132,7 @@ fun ShowSeasonCard(
                             item.seasonNumber.toString()
                         ),
                         modifier = Modifier.padding(4.dp),
-                        style = MaterialTheme.typography.h6
+                        style = MaterialTheme.typography.headlineMedium
                     )
                 }
 
@@ -144,7 +143,7 @@ fun ShowSeasonCard(
                             item.premiereDate
                         ),
                         modifier = Modifier.padding(2.dp),
-                        style = MaterialTheme.typography.caption
+                        style = MaterialTheme.typography.labelMedium
                     )
                 }
 
@@ -155,7 +154,7 @@ fun ShowSeasonCard(
                             item.endDate
                         ),
                         modifier = Modifier.padding(2.dp),
-                        style = MaterialTheme.typography.caption
+                        style = MaterialTheme.typography.labelMedium
                     )
                 }
 
@@ -170,7 +169,7 @@ fun ShowSeasonCard(
                             bottom = 2.dp,
                             end = 4.dp
                         ),
-                        style = MaterialTheme.typography.caption
+                        style = MaterialTheme.typography.labelMedium
                     )
                 }
             }

--- a/app/src/main/java/com/theupnextapp/ui/theme/Color.kt
+++ b/app/src/main/java/com/theupnextapp/ui/theme/Color.kt
@@ -1,0 +1,23 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Ahmed Tikiwa
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.theupnextapp.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val Teal500 = Color(0xFF009688)
+val Purple500 = Color(0xFF6200EE)
+val Teal600 = Color(0xFF00897B)
+
+val Teal200 = Color(0xFF80CBC4)
+val Purple200 = Color(0xFFBB86FC)
+val Teal700 = Color(0xFF00796B)

--- a/app/src/main/java/com/theupnextapp/ui/theme/Theme.kt
+++ b/app/src/main/java/com/theupnextapp/ui/theme/Theme.kt
@@ -1,0 +1,57 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Ahmed Tikiwa
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.theupnextapp.ui.theme
+
+import android.os.Build
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+
+private val DarkColorTheme = darkColorScheme(
+    primary = Teal500,
+    secondary = Purple500,
+    tertiary = Teal600
+)
+
+private val LightColorTheme = lightColorScheme(
+    primary = Teal200,
+    secondary = Purple200,
+    tertiary = Teal700
+)
+
+@Composable
+fun UpnextTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    dynamicColor: Boolean = true,
+    content: @Composable () -> Unit
+) {
+    val colorScheme = when {
+        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            val context = LocalContext.current
+            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        }
+        darkTheme -> DarkColorTheme
+        else -> LightColorTheme
+    }
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = Typography,
+        content = content
+    )
+}

--- a/app/src/main/java/com/theupnextapp/ui/theme/Type.kt
+++ b/app/src/main/java/com/theupnextapp/ui/theme/Type.kt
@@ -1,0 +1,29 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Ahmed Tikiwa
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.theupnextapp.ui.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+val Typography = Typography(
+    bodyLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.5.sp
+    )
+)

--- a/app/src/main/java/com/theupnextapp/ui/traktAccount/TraktAccountFragment.kt
+++ b/app/src/main/java/com/theupnextapp/ui/traktAccount/TraktAccountFragment.kt
@@ -26,7 +26,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -42,7 +42,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @ExperimentalFoundationApi
-@ExperimentalMaterialApi
+@ExperimentalMaterial3Api
 @AndroidEntryPoint
 class TraktAccountFragment : BaseFragment() {
 

--- a/app/src/main/java/com/theupnextapp/ui/traktAccount/TraktAccountFragment.kt
+++ b/app/src/main/java/com/theupnextapp/ui/traktAccount/TraktAccountFragment.kt
@@ -30,7 +30,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import com.google.android.material.composethemeadapter.MdcTheme
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.theupnextapp.MainActivity
 import com.theupnextapp.R
@@ -38,6 +37,7 @@ import com.theupnextapp.databinding.FragmentTraktAccountBinding
 import com.theupnextapp.domain.ShowDetailArg
 import com.theupnextapp.domain.TraktConnectionArg
 import com.theupnextapp.ui.common.BaseFragment
+import com.theupnextapp.ui.theme.UpnextTheme
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -67,7 +67,7 @@ class TraktAccountFragment : BaseFragment() {
         binding.composeContainer.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
-                MdcTheme {
+                UpnextTheme {
                     TraktAccountScreen(
                         viewModel = viewModel,
                         onConnectToTraktClick = {

--- a/app/src/main/java/com/theupnextapp/ui/traktAccount/TraktAccountScreen.kt
+++ b/app/src/main/java/com/theupnextapp/ui/traktAccount/TraktAccountScreen.kt
@@ -37,12 +37,12 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.material.Button
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.LinearProgressIndicator
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
@@ -61,7 +61,7 @@ import com.theupnextapp.ui.components.SectionHeadingText
 import com.theupnextapp.ui.widgets.ListPosterCard
 
 @ExperimentalFoundationApi
-@ExperimentalMaterialApi
+@ExperimentalMaterial3Api
 @Composable
 fun TraktAccountScreen(
     viewModel: TraktAccountViewModel,
@@ -107,7 +107,7 @@ fun TraktAccountScreen(
 }
 
 
-@ExperimentalMaterialApi
+@ExperimentalMaterial3Api
 @ExperimentalFoundationApi
 @Composable
 fun AccountArea(
@@ -171,7 +171,7 @@ fun ConnectToTrakt(
     }
 }
 
-@ExperimentalMaterialApi
+@ExperimentalMaterial3Api
 @ExperimentalFoundationApi
 @Composable
 fun FavoritesList(
@@ -200,7 +200,7 @@ fun FavoritesList(
                 .clickable { onLogoutClick() },
             textAlign = TextAlign.Center,
             fontWeight = FontWeight.Bold,
-            style = MaterialTheme.typography.body2
+            style = MaterialTheme.typography.bodyMedium
         )
 
         SectionHeadingText(
@@ -239,7 +239,7 @@ fun EmptyFavoritesList() {
                 .align(Alignment.CenterHorizontally)
                 .fillMaxWidth(0.7f),
             text = stringResource(id = R.string.trakt_account_favorites_empty),
-            style = MaterialTheme.typography.body2
+            style = MaterialTheme.typography.bodyMedium
         )
     }
 }

--- a/app/src/main/java/com/theupnextapp/ui/widgets/ListPosterCard.kt
+++ b/app/src/main/java/com/theupnextapp/ui/widgets/ListPosterCard.kt
@@ -26,9 +26,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.Card
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.MaterialTheme
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
@@ -38,7 +38,7 @@ import com.theupnextapp.ui.components.PosterAttributionItem
 import com.theupnextapp.ui.components.PosterImage
 import com.theupnextapp.ui.components.PosterTitleTextItem
 
-@ExperimentalMaterialApi
+@ExperimentalMaterial3Api
 @Composable
 fun ListPosterCard(
     itemName: String?,
@@ -46,7 +46,6 @@ fun ListPosterCard(
     onClick: () -> Unit
 ) {
     Card(
-        elevation = 4.dp,
         shape = MaterialTheme.shapes.large,
         modifier = Modifier.padding(4.dp),
         onClick = onClick

--- a/app/src/main/java/com/theupnextapp/ui/widgets/SearchListCard.kt
+++ b/app/src/main/java/com/theupnextapp/ui/widgets/SearchListCard.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.theupnextapp.R
 import com.theupnextapp.common.utils.models.getNameAndReleaseYearResource
@@ -77,12 +78,13 @@ fun SearchListCard(
                         item.premiered?.substring(0, 4).toString()
                     ),
                     modifier = Modifier.padding(4.dp),
-                    style = MaterialTheme.typography.headlineLarge
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Bold
                 )
                 Text(
                     text = item.status.toString(),
                     modifier = Modifier.padding(4.dp),
-                    style = MaterialTheme.typography.labelMedium
+                    style = MaterialTheme.typography.bodySmall
                 )
             }
         }

--- a/app/src/main/java/com/theupnextapp/ui/widgets/SearchListCard.kt
+++ b/app/src/main/java/com/theupnextapp/ui/widgets/SearchListCard.kt
@@ -28,10 +28,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.Card
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -43,14 +43,13 @@ import com.theupnextapp.common.utils.models.getNameAndReleaseYearResource
 import com.theupnextapp.domain.ShowSearch
 import com.theupnextapp.ui.components.PosterImage
 
-@ExperimentalMaterialApi
+@ExperimentalMaterial3Api
 @Composable
 fun SearchListCard(
     item: ShowSearch,
     onClick: () -> Unit
 ) {
     Card(
-        elevation = 4.dp,
         shape = MaterialTheme.shapes.large,
         modifier = Modifier
             .fillMaxWidth()
@@ -78,12 +77,12 @@ fun SearchListCard(
                         item.premiered?.substring(0, 4).toString()
                     ),
                     modifier = Modifier.padding(4.dp),
-                    style = MaterialTheme.typography.h6
+                    style = MaterialTheme.typography.headlineLarge
                 )
                 Text(
                     text = item.status.toString(),
                     modifier = Modifier.padding(4.dp),
-                    style = MaterialTheme.typography.caption
+                    style = MaterialTheme.typography.labelMedium
                 )
             }
         }

--- a/app/src/main/res/layout/layout_show_detail_buttons_trakt_authorized.xml
+++ b/app/src/main/res/layout/layout_show_detail_buttons_trakt_authorized.xml
@@ -36,7 +36,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_add_to_favorites"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -55,7 +55,7 @@
             app:layout_constraintTop_toTopOf="parent"
             app:showHideView="@{!viewModel.isFavoriteShow}" />
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_remove_from_favorites"
             style="?materialButtonOutlinedStyle"
             android:layout_width="0dp"
@@ -76,7 +76,7 @@
             app:showHideView="@{viewModel.isFavoriteShow}"
             tools:visibility="visible" />
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_show_seasons"
             android:layout_width="0dp"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/layout_show_detail_buttons_trakt_unauthorized.xml
+++ b/app/src/main/res/layout/layout_show_detail_buttons_trakt_unauthorized.xml
@@ -35,7 +35,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_show_seasons"
             android:layout_width="0dp"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/layout_trakt_account_not_authorized.xml
+++ b/app/src/main/res/layout/layout_trakt_account_not_authorized.xml
@@ -65,7 +65,7 @@
             app:layout_constraintTop_toBottomOf="@id/trakt_logo"
             app:showHideView="@{!viewModel.isAuthorizedOnTrakt}" />
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             style="?materialButtonStyle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/load_state_footer.xml
+++ b/app/src/main/res/layout/load_state_footer.xml
@@ -52,7 +52,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/progress_bar_load_state" />
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/button_load_state_retry"
             style="?materialButtonOutlinedStyle"
             android:layout_width="wrap_content"

--- a/app/src/main/res/values/shape.xml
+++ b/app/src/main/res/values/shape.xml
@@ -22,12 +22,12 @@
 
 <resources>
 
-    <style name="ShapeAppearance.Upnext.SmallComponent" parent="ShapeAppearance.MaterialComponents.SmallComponent">
+    <style name="ShapeAppearance.Upnext.SmallComponent" parent="ShapeAppearance.Material3.SmallComponent">
         <item name="cornerFamily">rounded</item>
         <item name="cornerRadius">32dp</item>
     </style>
 
-    <style name="ShapeAppearance.Upnext.LargeComponent" parent="ShapeAppearance.MaterialComponents.LargeComponent">
+    <style name="ShapeAppearance.Upnext.LargeComponent" parent="ShapeAppearance.Material3.LargeComponent">
         <item name="cornerFamily">rounded</item>
         <item name="cornerSizeTopLeft">12dp</item>
         <item name="cornerSizeTopRight">12dp</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -21,10 +21,10 @@
 
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="ThemeOverlay.Upnext.Toolbar.PopupOverlay" parent="ThemeOverlay.MaterialComponents.Light" />
+    <style name="ThemeOverlay.Upnext.Toolbar.PopupOverlay" parent="ThemeOverlay.Material3.Light" />
 
     <!-- Bottom Sheet -->
-    <style name="ThemeOverlay.Upnext.BottomSheetDialog" parent="Theme.MaterialComponents.BottomSheetDialog">
+    <style name="ThemeOverlay.Upnext.BottomSheetDialog" parent="Theme.Material3.DayNight.BottomSheetDialog">
         <item name="android:windowIsFloating">false</item>
         <item name="bottomSheetStyle">@style/Widget.Upnext.BottomSheet.Modal</item>
         <item name="android:navigationBarColor">?attr/colorSurface</item>
@@ -37,7 +37,7 @@
         <item name="shapeAppearanceOverlay">?attr/shapeAppearanceLargeComponent</item>
     </style>
 
-    <style name="Widget.Upnext.Toolbar.Surface" parent="@style/Widget.MaterialComponents.Toolbar.Surface">
+    <style name="Widget.Upnext.Toolbar.Surface" parent="@style/Widget.Material3.Toolbar.Surface">
         <item name="titleTextAppearance">@style/TextAppearance.Widget.Upnext.Toolbar.Title</item>
     </style>
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -45,9 +45,6 @@
         <item name="showSeasonTraktCollectedTagStrokeColor">@color/purple_200</item>
         <item name="favoritesEpisodeOverlayColor">@color/orange_500</item>
 
-        <!-- Material Shape Attributes -->
-        <item name="shapeAppearanceLargeComponent">@style/ShapeAppearance.Upnext.LargeComponent
-        </item>
         <item name="shapeAppearanceShowCast">@style/ShapeAppearance.Upnext.Image.Circle</item>
 
         <!-- Material Components -->
@@ -74,11 +71,9 @@
         <item name="bottomNavigationInactive">
             @style/TextAppearance.Upnext.BottomNavigation.TextInactive
         </item>
-
-        <item name="materialButtonStyle">@style/Widget.Upnext.Button</item>
     </style>
 
-    <style name="Base.Theme.MaterialTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="Base.Theme.MaterialTheme" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="android:windowBackground">?android:colorBackground</item>
         <item name="android:windowLightStatusBar" tools:ignore="NewApi">true</item>
         <item name="android:statusBarColor">?attr/colorSurface</item>
@@ -89,11 +84,6 @@
         <item name="android:navigationBarDividerColor" tools:ignore="NewApi">
             ?attr/colorControlHighlight
         </item>
-    </style>
-
-    <style name="Widget.Upnext.Button" parent="Widget.MaterialComponents.Button">
-        <item name="shapeAppearance">@style/ShapeAppearance.Upnext.SmallComponent</item>
-        <item name="android:padding">16dp</item>
     </style>
 
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
         appcompat_version = "1.4.2"
 
         compose_activity_version = "1.4.0"
-        compose_material_version = "1.2.0-rc01"
+        compose_material_version = "1.0.0-alpha13"
         compose_animation_version = "1.2.0-rc01"
         compose_ui_version = "1.1.1"
         compose_viewmodel_version = "2.4.1"

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,6 @@ buildscript {
         compose_ui_test_version = "1.1.1"
         compose_coil_version = "1.4.0"
         compose_hilt_navigation_version = "1.0.0"
-        compose_theme_adapter_version = "1.1.11"
 
         constraintlayout_version = "2.1.4"
 


### PR DESCRIPTION
- Added Compose Material 3 dependencies 
- Removed the Compose Material Theme Adapter dependency
- Replaced import references for `androidx.compose.material` to `androidx.compose.material3`
- Updated `@ExperimentalMaterialApi` annotation to `@ExperimentalMaterial3Api`
- Updated the `MaterialTheme.typography` references to Material Design 3 references
- Added `UpnextTheme` Compose theme definition with respective `ui/Theme.kt`, `ui/Color.kt` and `ui/Type.kt`
- Changed references to `MdcTheme` to `UpnextTheme`

Closes #49 

**Screenshots:**


| Search Screen Before | Search Screen After |
| ---------------------- | -------------------- |
| <img src="https://user-images.githubusercontent.com/2282990/174492678-44d21de7-5d42-4c40-b864-30124c3abaf2.png" width="246" /> | <img src="https://user-images.githubusercontent.com/2282990/174492714-ddd43640-c976-416a-a5d6-e65b31960c02.png"  width="246" /> |

| Dashboard Screen Before | Dashboard Screen After |
| ---------------------- | -------------------- |
| <img src="https://user-images.githubusercontent.com/2282990/174493418-34a03e6e-ff08-423c-89b0-8ad23033a59c.png" width="246" /> | <img src="https://user-images.githubusercontent.com/2282990/174493334-94797844-6419-45e8-b4ed-963be0fb3b99.png" width="246" /> |

| Explore Screen Before | Explore Screen After |
| ---------------------- | -------------------- | 
| <img src="https://user-images.githubusercontent.com/2282990/174493517-848b565c-dd37-46d2-af33-23f7fea1f261.png" width="246" /> | <img src="https://user-images.githubusercontent.com/2282990/174493569-7d1b0c0d-f781-488e-9422-bafe9a1b3484.png" width="246" />

| Account Screen Before | Account Screen After |
| ---------------------- | -------------------- | 
| <img src="https://user-images.githubusercontent.com/2282990/174493705-e872f771-71eb-4dff-aa6f-1c697d010d60.png" width="246" /> | <img src="https://user-images.githubusercontent.com/2282990/174493747-2699daed-e31d-40be-a8d7-202e2bbd3b4a.png" width="246" />
