### PR TITLE
Resolved NumberFormatException on show detail screen

### DIFF
--- a/app/src/main/java/com/theupnextapp/domain/ShowDetailSummary.kt
+++ b/app/src/main/java/com/theupnextapp/domain/ShowDetailSummary.kt
@@ -96,3 +96,24 @@ data class ShowDetailSummary(
     }
 
 }
+
+fun emptyShowData(): ShowDetailSummary {
+    return ShowDetailSummary(
+        airDays = null,
+        averageRating = null,
+        id = -1,
+        imdbID = null,
+        genres = null,
+        language = null,
+        mediumImageUrl = null,
+        name = null,
+        originalImageUrl = null,
+        summary = "No show data has been currently provided for this show.",
+        time = null,
+        status = null,
+        previousEpisodeHref = null,
+        nextEpisodeHref = null,
+        nextEpisodeLinkedId = null,
+        previousEpisodeLinkedId = null
+    )
+}

--- a/app/src/main/java/com/theupnextapp/ui/showDetail/ShowDetailScreen.kt
+++ b/app/src/main/java/com/theupnextapp/ui/showDetail/ShowDetailScreen.kt
@@ -291,11 +291,13 @@ fun PosterAndMetadata(showSummary: ShowDetailSummary?) {
                 }
             }
 
-            Text(
-                text = stringResource(id = R.string.tv_maze_creative_commons_attribution_text_multiple),
-                style = MaterialTheme.typography.labelMedium,
-                modifier = Modifier.padding(8.dp)
-            )
+            if (!showSummary?.originalImageUrl.isNullOrEmpty()) {
+                Text(
+                    text = stringResource(id = R.string.tv_maze_creative_commons_attribution_text_multiple),
+                    style = MaterialTheme.typography.labelMedium,
+                    modifier = Modifier.padding(8.dp)
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/theupnextapp/ui/showDetail/ShowDetailViewModel.kt
+++ b/app/src/main/java/com/theupnextapp/ui/showDetail/ShowDetailViewModel.kt
@@ -36,6 +36,7 @@ import com.theupnextapp.domain.ShowDetailArg
 import com.theupnextapp.domain.ShowDetailSummary
 import com.theupnextapp.domain.ShowNextEpisode
 import com.theupnextapp.domain.ShowPreviousEpisode
+import com.theupnextapp.domain.emptyShowData
 import com.theupnextapp.repository.ShowDetailRepository
 import com.theupnextapp.repository.TraktRepository
 import com.theupnextapp.ui.common.BaseTraktViewModel
@@ -45,7 +46,6 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
 class ShowDetailViewModel @AssistedInject constructor(
@@ -112,25 +112,28 @@ class ShowDetailViewModel @AssistedInject constructor(
     private fun getShowSummary(show: ShowDetailArg) {
         viewModelScope.launch {
             show.showId?.let {
-                showDetailRepository.getShowSummary(it.toInt()).collect { result ->
-                    when (result) {
-                        is Result.Success -> {
-                            val showSummary = result.data
-                            _showSummary.value = showSummary
-                            getShowPreviousEpisode(showSummary.previousEpisodeHref)
-                            getShowNextEpisode(showSummary.nextEpisodeHref)
-                            getTraktShowRating(showSummary.imdbID)
-                            getTraktShowStats(showSummary.imdbID)
-                            checkIfShowIsTraktFavorite(showSummary.imdbID)
+                if (it.isNotEmpty()) {
+                    showDetailRepository.getShowSummary(it.toInt()).collect { result ->
+                        when (result) {
+                            is Result.Success -> {
+                                val showSummary = result.data
+                                _showSummary.value = showSummary
+                                getShowPreviousEpisode(showSummary.previousEpisodeHref)
+                                getShowNextEpisode(showSummary.nextEpisodeHref)
+                                getTraktShowRating(showSummary.imdbID)
+                                getTraktShowStats(showSummary.imdbID)
+                                checkIfShowIsTraktFavorite(showSummary.imdbID)
+                            }
+                            is Result.Loading -> {
+                                isLoading.value = result.status
+                            }
+                            else -> {}
                         }
-                        is Result.Loading -> {
-                            isLoading.value = result.status
-                        }
-                        else -> {}
                     }
-
+                    getShowCast(it.toInt())
+                } else {
+                    _showSummary.value = emptyShowData()
                 }
-                getShowCast(it.toInt())
             }
         }
     }


### PR DESCRIPTION
- Added a null check for the `showId` variable in `ShowDetailViewModel#getShowSummary()`
- If showId is `null` then `ShowDetailSummary#emptyShowData()` is displayed
- Updated `ShowDetailScreen` composable to only display the image attribution if the image url is not empty
- Added a null check for the showId as well in `ShowSeasonsViewModel#init`

Closes #55  