### PR TITLE
Updated dependencies and targetSdk version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,14 +35,14 @@ def localProperties = new Properties()
 localProperties.load(new FileInputStream(rootProject.file("local.properties")))
 
 android {
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.theupnextapp"
         minSdkVersion 22
-        targetSdkVersion 32
-        versionCode 178
-        versionName "3.4.2"
+        targetSdkVersion 33
+        versionCode 179
+        versionName "3.4.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         javaCompileOptions {

--- a/app/src/main/java/com/theupnextapp/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/theupnextapp/ui/search/SearchScreen.kt
@@ -118,6 +118,7 @@ fun SearchArea(
     }
 }
 
+@ExperimentalMaterial3Api
 @ExperimentalComposeUiApi
 @Composable
 fun SearchForm(
@@ -134,6 +135,7 @@ fun SearchForm(
     )
 }
 
+@ExperimentalMaterial3Api
 @Composable
 fun SearchInputField(
     modifier: Modifier = Modifier,

--- a/build.gradle
+++ b/build.gradle
@@ -23,14 +23,14 @@ buildscript {
     ext {
         androidx_preference_version = "1.2.0"
 
-        appcompat_version = "1.4.2"
+        appcompat_version = "1.6.0-alpha05"
 
-        compose_activity_version = "1.5.0"
-        compose_material_version = "1.0.0-alpha14"
-        compose_animation_version = "1.3.0-alpha01"
-        compose_ui_version = "1.1.1"
-        compose_viewmodel_version = "2.5.0"
-        compose_ui_test_version = "1.1.1"
+        compose_activity_version = "1.5.1"
+        compose_material_version = "1.0.0-alpha15"
+        compose_animation_version = "1.3.0-alpha02"
+        compose_ui_version = "1.2.0"
+        compose_viewmodel_version = "2.5.1"
+        compose_ui_test_version = "1.2.0"
         compose_coil_version = "1.4.0"
         compose_hilt_navigation_version = "1.0.0"
 
@@ -46,7 +46,7 @@ buildscript {
 
         glide_version = '4.12.0'
 
-        gradle_version = '7.2.1'
+        gradle_version = '7.2.2'
 
         google_services = '4.3.10'
 
@@ -56,9 +56,9 @@ buildscript {
         hilt_work_version = "1.0.0"
         hilt_version = "2.41"
 
-        firebase_analytics_version = "21.0.0"
-        firebase_core_version = "21.0.0"
-        firebase_crashlytics_version = "18.2.11"
+        firebase_analytics_version = "21.1.0"
+        firebase_core_version = "21.1.0"
+        firebase_crashlytics_version = "18.2.12"
         firebase_crashlytics_gradle_version = "2.9.1"
         firebase_performance_monitoring_version = "20.1.0"
         firebase_performance_monitoring_gradle_version = "1.4.1"
@@ -70,13 +70,13 @@ buildscript {
 
         leakcanary_version = '2.7'
 
-        lifecycle_version = "2.5.0"
+        lifecycle_version = "2.5.1"
 
-        material_version = "1.7.0-alpha02"
+        material_version = "1.7.0-alpha03"
 
         moshi_version = '1.12.0'
         
-        navigation_version = "2.5.0"
+        navigation_version = "2.5.1"
 
         okhttp_version = '5.0.0-alpha.2'
         okhttp_logging_interceptor_version = '5.0.0-alpha.2'
@@ -89,7 +89,7 @@ buildscript {
         retrofit_version = "2.9.0"
         retrofit_coroutines_adapter_version = "0.9.2"
 
-        room_version = "2.4.2"
+        room_version = "2.4.3"
         work_version = "2.8.0-alpha02"
         timber_version = '5.0.1'
     }


### PR DESCRIPTION
- Bumped app version to `3.4.3 (179)`
- Updated `targetSdk` version from `32` to `33`
- Updated the following dependencies:

-- appcompat version `1.4.2` => `1.6.0-alpha05`
-- compose activity version  `1.5.0 => 1.5.1`
-- compose material version `1.0.0-alpha14` => `1.0.0-alpha15`
-- compose animation version `1.3.0-alpha01` => `1.3.0-alpha02`
-- compose UI version `1.1.1` => `1.2.0`
-- compose viewModel `2.5.0` => `2.5.1`
-- compose UI test version `1.1.1` => `1.2.0`
-- firebase_analytics_version `21.0.0` => `21.2.0`
-- firebase_core_version `21.0.0` => `21.2.0`
-- firebase_crashlytics_version `18.2.11` => `18.2.12`
-- material version `1.7.0-alpha02` => `1.7.0-alpha03`

Closes #59 