### PR TITLE
Fix extraGeneratedResDir error while trying to create release build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ buildscript {
 
         gradle_version = '7.3.1'
 
-        google_services = '4.3.10'
+        google_services = '4.3.14'
 
         gson_version = "2.9.0"
 


### PR DESCRIPTION
Updated google-services version from `4.3.10` to `4.3.14` in order to resolve error while trying to create release build

Closes #69 