### PR TITLE
Address issue with Trakt rating bar not occupying full width

### DIFF
--- a/app/src/main/java/com/theupnextapp/ui/showDetail/ShowDetailScreen.kt
+++ b/app/src/main/java/com/theupnextapp/ui/showDetail/ShowDetailScreen.kt
@@ -590,7 +590,7 @@ fun TraktRatingVisual(ratingData: TraktShowRating) {
     ) {
         distributionList.asReversed().forEach { distribution ->
             val progressValue =
-                (distribution.value.toFloat() / (ratingData.votes?.toFloat() ?: 0f)) * 100.0f
+                (distribution.value.toFloat() / (ratingData.votes?.toFloat() ?: 0f))
 
             LinearProgress(
                 ratingLevel = distribution.score,
@@ -608,7 +608,7 @@ fun LinearProgress(
     Row(
         modifier = Modifier
             .padding(4.dp)
-            .width(30.dp),
+            .fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(text = ratingLevel)
@@ -623,7 +623,7 @@ fun LinearProgress(
 @Preview
 @Composable
 fun LinearProgressPreview() {
-    Row {
+    Row(modifier = Modifier.fillMaxWidth()) {
         Column(
             verticalArrangement = Arrangement.Top,
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -635,11 +635,11 @@ fun LinearProgressPreview() {
 
         Column(
             verticalArrangement = Arrangement.SpaceEvenly,
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.Start
         ) {
             LinearProgress(
                 ratingLevel = "10",
-                progress = 0.43f,
+                progress = 0.63f,
             )
             LinearProgress(
                 ratingLevel = "9",


### PR DESCRIPTION
Fix issue with progress indicator for the Trakt ratings not occupying full screen on show detail screen

| Before | After |
| ------ | ------ |
| <img src="https://user-images.githubusercontent.com/2282990/216836255-b70ae268-189e-40ec-8ad6-2889a81d6c38.png" width="250"/> | <img src="https://user-images.githubusercontent.com/2282990/216836502-2b52583f-1129-4a94-8a93-60006d002e66.png" width="250"/> |

Closes #74 
