### PR TITLE
Enable configuration cache for builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+org.gradle.unsafe.configuration-cache=true


### PR DESCRIPTION
Added `org.gradle.unsafe.configuration-cache=true` to gradle.properties file