### PR TITLE
Added missing functionality for the logout button on the Trakt account screen

### DIFF
--- a/app/src/main/java/com/theupnextapp/ui/traktAccount/TraktAccountScreen.kt
+++ b/app/src/main/java/com/theupnextapp/ui/traktAccount/TraktAccountScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LinearProgressIndicator
@@ -87,6 +88,8 @@ fun TraktAccountScreen(
 
     val favoriteShowsList = viewModel.favoriteShows.observeAsState()
 
+    val confirmDisconnectFromTrakt = viewModel.confirmDisconnectFromTrakt.observeAsState()
+
     val isLoading = viewModel.isLoading.observeAsState()
 
     val context = LocalContext.current
@@ -129,15 +132,55 @@ fun TraktAccountScreen(
                             .fillMaxWidth()
                     )
                 }
+
+                if (confirmDisconnectFromTrakt.value == true) {
+                    DisconnectTraktDialog(
+                        onDismissed = { viewModel.onDisconnectFromTraktRefused() },
+                        onConfirmed = { viewModel.onDisconnectConfirm() }
+                    )
+                }
             }
         }
     }
 }
 
+@Composable
+private fun DisconnectTraktDialog(
+    onDismissed: () -> Unit,
+    onConfirmed: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = { onDismissed() },
+        title = {
+            Text(
+                text = stringResource(id = R.string.disconnect_from_trakt_dialog_title)
+            )
+        },
+        text = {
+            Text(
+                text = stringResource(id = R.string.disconnect_from_trakt_dialog_message)
+            )
+        },
+        confirmButton = {
+            Button(onClick = { onConfirmed() }) {
+                Text(text = stringResource(id = R.string.disconnect_from_trakt_dialog_confirm))
+            }
+        },
+        dismissButton = {
+            Button(onClick = { onDismissed() }) {
+                Text(text = stringResource(id = R.string.disconnect_from_trakt_dialog_cancel))
+            }
+        }
+    )
+}
+
 fun openCustomTab(context: Context) {
     val packageName = "com.android.chrome"
 
-    val traktUrl = "https://trakt.tv/oauth/authorize?response_type=code&client_id=${BuildConfig.TRAKT_CLIENT_ID}&redirect_uri=${BuildConfig.TRAKT_REDIRECT_URI}"
+    val traktUrl =
+        "https://trakt.tv/oauth/authorize?response_type=code&client_id=" +
+                "${BuildConfig.TRAKT_CLIENT_ID}&redirect_uri=" +
+                BuildConfig.TRAKT_REDIRECT_URI
 
     val activity = (context as? Activity)
 

--- a/app/src/main/java/com/theupnextapp/ui/traktAccount/TraktAccountViewModel.kt
+++ b/app/src/main/java/com/theupnextapp/ui/traktAccount/TraktAccountViewModel.kt
@@ -67,7 +67,7 @@ class TraktAccountViewModel @Inject constructor(
         _confirmDisconnectFromTrakt.postValue(true)
     }
 
-    fun onDisconnectFromTraktConfirmed() {
+    fun onDisconnectFromTraktRefused() {
         _confirmDisconnectFromTrakt.postValue(false)
     }
 
@@ -76,6 +76,7 @@ class TraktAccountViewModel @Inject constructor(
             traktRepository.clearFavorites()
             revokeTraktAccessToken()
         }
+        _confirmDisconnectFromTrakt.postValue(false)
     }
 
     fun onCustomTabOpened() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -129,8 +129,11 @@
     <string name="connect_to_trakt_button">Connect to Trakt</string>
     <string name="trakt_connection_status_connected">Connection status: Connected</string>
     <string name="trakt_connection_status_disconnect">Logout</string>
-    <string name="disconnect_from_trakt_dialog_message">Are you sure you want to disconnect your Trakt account from
+    <string name="disconnect_from_trakt_dialog_title">Disconnect  Trakt account?</string>
+    <string name="disconnect_from_trakt_dialog_message">Continue with disconnecting your Trakt account from
         Upnext: TV Series Manager? You will need to reconnect your Trakt account for the data to be synchronized again.</string>
+    <string name="disconnect_from_trakt_dialog_confirm">Logout</string>
+    <string name="disconnect_from_trakt_dialog_cancel">Cancel</string>
     <string name="favorite_title_and_release_year">%1$s (%2$s)</string>
     <string name="favorite_title_no_year">%1$s</string>
     <string name="trakt_account_favorites_empty">You currently have no favorite shows. Search for your favorite show and click \'Add Favorite\' so it can appear here.</string>


### PR DESCRIPTION
Added the missing trigger which handles the onClick action for the logout button on the Trakt account screen

<img src="https://github.com/akitikkx/upnext/assets/2282990/7ad29318-4200-44a2-b2fb-3999fad953cb" width="250">

Closes #131 