### PR TITLE
Introduced the new NavigableListDetailPaneScaffold

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -124,8 +124,11 @@ dependencies {
     implementation libs.android.ktx
     implementation libs.constraintlayout
     implementation libs.android.material
+    implementation libs.android.material3.adaptive
     implementation libs.android.material3.adaptive.layout
+    implementation libs.android.material3.adaptive.navigation
     implementation libs.android.material3.adaptive.navigation.suite
+    implementation libs.androidx.adaptive.navigation.android
 
     // Compose
     // Integration with activities

--- a/app/src/main/java/com/theupnextapp/repository/DashboardRepository.kt
+++ b/app/src/main/java/com/theupnextapp/repository/DashboardRepository.kt
@@ -54,13 +54,13 @@ class DashboardRepository(
     private val firebaseCrashlytics: FirebaseCrashlytics
 ) : BaseRepository(upnextDao = upnextDao, tvMazeService = tvMazeService) {
 
-    private val _isLoadingYesterdayShows = MutableLiveData<Boolean>()
+    private val _isLoadingYesterdayShows = MutableLiveData<Boolean>(false)
     val isLoadingYesterdayShows: LiveData<Boolean> = _isLoadingYesterdayShows
 
-    private val _isLoadingTodayShows = MutableLiveData<Boolean>()
+    private val _isLoadingTodayShows = MutableLiveData<Boolean>(false)
     val isLoadingTodayShows: LiveData<Boolean> = _isLoadingTodayShows
 
-    private val _isLoadingTomorrowShows = MutableLiveData<Boolean>()
+    private val _isLoadingTomorrowShows = MutableLiveData<Boolean>(false)
     val isLoadingTomorrowShows: LiveData<Boolean> = _isLoadingTomorrowShows
 
     val yesterdayShows: Flow<List<ScheduleShow>>
@@ -130,6 +130,10 @@ class DashboardRepository(
                         )
                     }
                     _isLoadingYesterdayShows.postValue(false)
+                } else {
+                    if (_isLoadingYesterdayShows.value == true) {
+                        _isLoadingYesterdayShows.postValue(false)
+                    }
                 }
             } catch (e: Exception) {
                 _isLoadingYesterdayShows.postValue(false)
@@ -182,6 +186,10 @@ class DashboardRepository(
                         )
                     }
                     _isLoadingTodayShows.postValue(false)
+                } else {
+                    if (_isLoadingTodayShows.value == true) {
+                        _isLoadingTodayShows.postValue(false)
+                    }
                 }
             } catch (e: Exception) {
                 _isLoadingTodayShows.postValue(false)
@@ -235,6 +243,10 @@ class DashboardRepository(
                         )
                     }
                     _isLoadingTomorrowShows.postValue(false)
+                } else {
+                    if (_isLoadingTomorrowShows.value == true) {
+                        _isLoadingTomorrowShows.postValue(false)
+                    }
                 }
             } catch (e: Exception) {
                 _isLoadingTomorrowShows.postValue(false)

--- a/app/src/main/java/com/theupnextapp/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/theupnextapp/ui/dashboard/DashboardScreen.kt
@@ -22,7 +22,6 @@
 package com.theupnextapp.ui.dashboard
 
 import androidx.activity.compose.ReportDrawnWhen
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -55,108 +54,116 @@ import com.theupnextapp.extensions.ReferenceDevices
 import com.theupnextapp.ui.components.SectionHeadingText
 import com.theupnextapp.ui.widgets.ListPosterCard
 
-@ExperimentalMaterial3WindowSizeClassApi
-@ExperimentalMaterial3Api
-@Destination<RootGraph>(start = true)
+@OptIn(
+    ExperimentalMaterial3WindowSizeClassApi::class,
+    ExperimentalMaterial3Api::class,
+)
+@Destination<RootGraph>
 @Composable
 fun DashboardScreen(
     viewModel: DashboardViewModel = hiltViewModel(),
     navigator: DestinationsNavigator
 ) {
     val yesterdayShowsList = viewModel.yesterdayShowsList.observeAsState()
-
     val todayShowsList = viewModel.todayShowsList.observeAsState()
-
     val tomorrowShowsList = viewModel.tomorrowShowsList.observeAsState()
-
     val scrollState = rememberScrollState()
-
-    val isLoading = viewModel.isLoading.observeAsState()
+    // Set initial value for isLoading
+    val isLoading = viewModel.isLoading.observeAsState(initial = true)
 
     Surface(modifier = Modifier.fillMaxSize()) {
         Column(
             modifier = Modifier
-                .verticalScroll(scrollState)
+                .fillMaxSize()
                 .testTag("dashboard_list")
         ) {
-            Box(modifier = Modifier.fillMaxSize()) {
-                Column(modifier = Modifier.padding(top = 8.dp)) {
-                    yesterdayShowsList.value?.let { list ->
-                        if (list.isNotEmpty()) {
-                            ShowsRow(
-                                list = list,
-                                rowTitle = stringResource(id = R.string.title_yesterday_shows)
-                            ) {
-                                navigator.navigate(
-                                    ShowDetailScreenDestination(
-                                        source = "dashboard",
-                                        showId = it.id.toString(),
-                                        showTitle = it.name,
-                                        showImageUrl = it.originalImage,
-                                        showBackgroundUrl = it.mediumImage
-                                    )
-                                )
-                            }
-                        }
-                    }
+            // Show LinearProgressIndicator at the top if loading
+            if (isLoading.value == true) {
+                LinearProgressIndicator(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 8.dp, vertical = 4.dp) // Adjust padding as needed
+                )
+            }
 
-                    todayShowsList.value?.let { list ->
-                        if (list.isNotEmpty()) {
-                            ShowsRow(
-                                list = list,
-                                rowTitle = stringResource(id = R.string.title_today_shows)
-                            ) {
-                                navigator.navigate(
-                                    ShowDetailScreenDestination(
-                                        source = "dashboard",
-                                        showId = it.id.toString(),
-                                        showTitle = it.name,
-                                        showImageUrl = it.originalImage,
-                                        showBackgroundUrl = it.mediumImage
-                                    )
+            // Scrollable content area
+            Column(
+                modifier = Modifier
+                    .weight(1f) // Allow this Column to take remaining space
+                    .verticalScroll(scrollState) // Make this part scrollable
+                    .padding(top = 8.dp)
+            ) {
+                // Yesterday Shows
+                yesterdayShowsList.value?.let { list ->
+                    if (list.isNotEmpty()) {
+                        ShowsRow(
+                            list = list,
+                            rowTitle = stringResource(id = R.string.title_yesterday_shows)
+                        ) {
+                            navigator.navigate(
+                                ShowDetailScreenDestination(
+                                    source = "dashboard",
+                                    showId = it.id.toString(),
+                                    showTitle = it.name,
+                                    showImageUrl = it.originalImage,
+                                    showBackgroundUrl = it.mediumImage
                                 )
-                            }
-                        }
-                    }
-
-                    tomorrowShowsList.value?.let { list ->
-                        if (list.isNotEmpty()) {
-                            ShowsRow(
-                                list = list,
-                                rowTitle = stringResource(id = R.string.title_tomorrow_shows)
-                            ) {
-                                navigator.navigate(
-                                    ShowDetailScreenDestination(
-                                        source = "dashboard",
-                                        showId = it.id.toString(),
-                                        showTitle = it.name,
-                                        showImageUrl = it.originalImage,
-                                        showBackgroundUrl = it.mediumImage
-                                    )
-                                )
-                            }
+                            )
                         }
                     }
                 }
 
-                if (isLoading.value == true) {
-                    LinearProgressIndicator(
-                        modifier = Modifier
-                            .padding(8.dp)
-                            .fillMaxWidth()
-                    )
+                // Today Shows
+                todayShowsList.value?.let { list ->
+                    if (list.isNotEmpty()) {
+                        ShowsRow(
+                            list = list,
+                            rowTitle = stringResource(id = R.string.title_today_shows)
+                        ) {
+                            navigator.navigate(
+                                ShowDetailScreenDestination(
+                                    source = "dashboard",
+                                    showId = it.id.toString(),
+                                    showTitle = it.name,
+                                    showImageUrl = it.originalImage,
+                                    showBackgroundUrl = it.mediumImage
+                                )
+                            )
+                        }
+                    }
+                }
+
+                // Tomorrow Shows
+                tomorrowShowsList.value?.let { list ->
+                    if (list.isNotEmpty()) {
+                        ShowsRow(
+                            list = list,
+                            rowTitle = stringResource(id = R.string.title_tomorrow_shows)
+                        ) {
+                            navigator.navigate(
+                                ShowDetailScreenDestination(
+                                    source = "dashboard",
+                                    showId = it.id.toString(),
+                                    showTitle = it.name,
+                                    showImageUrl = it.originalImage,
+                                    showBackgroundUrl = it.mediumImage
+                                )
+                            )
+                        }
+                    }
                 }
             }
         }
     }
 
     ReportDrawnWhen {
-        !yesterdayShowsList.value.isNullOrEmpty() ||
+        (!yesterdayShowsList.value.isNullOrEmpty() ||
                 !tomorrowShowsList.value.isNullOrEmpty() ||
-                !todayShowsList.value.isNullOrEmpty()
+                !todayShowsList.value.isNullOrEmpty()) || (isLoading.value == false)
     }
 }
 
+// ShowsRow and PreviewProvider remain the same
 @ExperimentalMaterial3WindowSizeClassApi
 @ExperimentalMaterial3Api
 @Composable

--- a/app/src/main/java/com/theupnextapp/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/theupnextapp/ui/dashboard/DashboardViewModel.kt
@@ -44,9 +44,7 @@ class DashboardViewModel @Inject constructor(
 ) : ViewModel() {
 
     val isLoadingYesterdayShows = dashboardRepository.isLoadingYesterdayShows
-
     val isLoadingTodayShows = dashboardRepository.isLoadingTodayShows
-
     val isLoadingTomorrowShows = dashboardRepository.isLoadingTomorrowShows
 
     val yesterdayShowsList = dashboardRepository.yesterdayShows.asLiveData()
@@ -83,14 +81,23 @@ class DashboardViewModel @Inject constructor(
     }
 
     val isLoading = MediatorLiveData<Boolean>().apply {
+        val updateLoadingState = {
+            // Value is true if any of the individual loading states are true
+            // Ensure you handle nulls from the LiveData sources if they haven't emitted yet.
+            // isLoadingYesterdayShows.value could be null initially.
+            value = (isLoadingYesterdayShows.value == true) ||
+                    (isLoadingTodayShows.value == true) ||
+                    (isLoadingTomorrowShows.value == true)
+        }
+
         addSource(isLoadingYesterdayShows) {
-            value = it
+            updateLoadingState()
         }
         addSource(isLoadingTodayShows) {
-            value = it
+            updateLoadingState()
         }
         addSource(isLoadingTomorrowShows) {
-            value = it
+            updateLoadingState()
         }
     }
 

--- a/app/src/main/java/com/theupnextapp/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/theupnextapp/ui/main/MainScreen.kt
@@ -12,72 +12,259 @@
 
 package com.theupnextapp.ui.main
 
+
+import AppNavigation
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.LocalActivity
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.layout.ThreePaneScaffoldRole
+import androidx.compose.material3.adaptive.navigation.NavigableListDetailPaneScaffold
+import androidx.compose.material3.adaptive.navigation.rememberSupportingPaneScaffoldNavigator
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.ramcosta.composedestinations.generated.NavGraphs
+import com.ramcosta.composedestinations.generated.destinations.EmptyDetailScreenDestination
+import com.ramcosta.composedestinations.generated.destinations.ShowDetailScreenDestination
+import com.ramcosta.composedestinations.generated.destinations.ShowSeasonEpisodesScreenDestination
+import com.ramcosta.composedestinations.generated.destinations.ShowSeasonsScreenDestination
 import com.ramcosta.composedestinations.generated.destinations.TraktAccountScreenDestination
+import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.ramcosta.composedestinations.utils.rememberDestinationsNavigator
-import com.ramcosta.composedestinations.utils.route
-import com.theupnextapp.ui.navigation.AppNavigation
+import com.ramcosta.composedestinations.utils.startDestination
+import com.theupnextapp.ui.dashboard.DashboardScreen
+import com.theupnextapp.ui.explore.ExploreScreen
+import com.theupnextapp.ui.search.SearchScreen
+import com.theupnextapp.ui.traktAccount.TraktAccountScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 
-@ExperimentalAnimationApi
-@ExperimentalFoundationApi
-@ExperimentalComposeUiApi
-@ExperimentalMaterial3Api
-@ExperimentalMaterial3WindowSizeClassApi
+
+@OptIn(
+    ExperimentalMaterial3AdaptiveApi::class,
+    ExperimentalAnimationApi::class,
+    ExperimentalFoundationApi::class,
+    ExperimentalComposeUiApi::class,
+    ExperimentalMaterial3Api::class,
+    ExperimentalMaterial3WindowSizeClassApi::class,
+    ExperimentalCoroutinesApi::class,
+)
 @Composable
 fun MainScreen(
     valueState: MutableState<String?>,
     onTraktAuthCompleted: () -> Unit,
 ) {
-    val navController = rememberNavController()
+    val scope = rememberCoroutineScope()
 
-    val navigator = navController.rememberDestinationsNavigator()
+    val activity = LocalActivity.current
+    val windowSizeClass = activity?.let { calculateWindowSizeClass(it) }
 
-    val currentBackStackEntryAsState by navController.currentBackStackEntryAsState()
-    val currentDestination = currentBackStackEntryAsState?.route()
+    val mainNavController = rememberNavController()
+    val destinationsNavigatorForDetail: DestinationsNavigator =
+        mainNavController.rememberDestinationsNavigator()
 
-    if (!valueState.value.isNullOrEmpty()) {
-        navigator.navigate(TraktAccountScreenDestination(code = valueState.value))
-        onTraktAuthCompleted()
+    // State to track the currently active top-level list section
+    var currentListSection by rememberSaveable { mutableStateOf(NavigationDestination.Dashboard) }
+
+    val navBackStackEntry by mainNavController.currentBackStackEntryAsState()
+    val currentRouteForDetailPane = navBackStackEntry?.destination?.route
+
+    val isDetailFlowActive = remember(currentRouteForDetailPane) {
+        val isActive = currentRouteForDetailPane?.let { route ->
+            route.startsWith(ShowDetailScreenDestination.baseRoute) ||
+                    route.startsWith(ShowSeasonsScreenDestination.baseRoute) ||
+                    route.startsWith(ShowSeasonEpisodesScreenDestination.baseRoute) ||
+                    route.startsWith(TraktAccountScreenDestination.baseRoute)
+                    // Explicitly ensure EmptyDetailScreen is NOT considered part of an active detail flow
+                    && route != EmptyDetailScreenDestination.route
+        } == true
+        isActive
+    }
+
+    val showDetailScreenArgs = remember(currentRouteForDetailPane, navBackStackEntry) {
+        if (currentRouteForDetailPane?.startsWith(ShowDetailScreenDestination.baseRoute) == true) {
+            navBackStackEntry?.let { ShowDetailScreenDestination.argsFrom(it) }
+        } else {
+            null
+        }
+    }
+
+    val listDetailNavigator = rememberSupportingPaneScaffoldNavigator<ThreePaneScaffoldRole>()
+
+    windowSizeClass?.let { wsc ->
+        LaunchedEffect(
+            isDetailFlowActive,
+            listDetailNavigator.currentDestination,
+            wsc.widthSizeClass
+        ) {
+            val currentPaneRole = listDetailNavigator.currentDestination?.pane
+
+            if (wsc.widthSizeClass == WindowWidthSizeClass.Compact) {
+                if (isDetailFlowActive) {
+                    if (currentPaneRole != ThreePaneScaffoldRole.Primary) {
+                        listDetailNavigator.navigateTo(ThreePaneScaffoldRole.Primary)
+                    }
+                } else {
+                    if (currentPaneRole != ThreePaneScaffoldRole.Secondary) {
+                        listDetailNavigator.navigateTo(ThreePaneScaffoldRole.Secondary)
+                    }
+                }
+            } else { // Medium or Expanded
+                if (isDetailFlowActive) {
+                    if (currentPaneRole != ThreePaneScaffoldRole.Primary) {
+                        listDetailNavigator.navigateTo(ThreePaneScaffoldRole.Primary)
+                    }
+                } else {
+                    if (currentPaneRole != ThreePaneScaffoldRole.Secondary) {
+                        listDetailNavigator.navigateTo(ThreePaneScaffoldRole.Secondary)
+                    }
+                }
+            }
+        }
+    }
+
+    // Back handler for adaptive layouts
+    BackHandler(enabled = listDetailNavigator.canNavigateBack() || isDetailFlowActive) {
+        if (isDetailFlowActive) { // If a detail screen is active in mainNavController
+            if (showDetailScreenArgs != null) { // If at the root of detail flow (ShowDetailScreen)
+                destinationsNavigatorForDetail.navigate(EmptyDetailScreenDestination) {
+                    popUpTo(NavGraphs.root.startDestination) { inclusive = true }
+                    launchSingleTop = true
+                }
+            } else {
+                // Deeper in detail flow (Seasons, Episodes)
+                mainNavController.popBackStack()
+            }
+            // isDetailFlowActive will become false once mainNavController is on EmptyDetailScreen or similar,
+            // which will trigger the LaunchedEffect above to set listDetailNavigator to Secondary.
+        } else if (listDetailNavigator.canNavigateBack()) {
+            scope.launch {
+                // Handles scaffold-level back, e.g., from an extra pane if one is used.
+                listDetailNavigator.navigateBack()
+            }
+        }
     }
 
     NavigationSuiteScaffold(
         navigationSuiteItems = {
-            NavigationDestination.entries.forEach {
+            NavigationDestination.entries.forEach { item ->
+                val isSelected = item == currentListSection
                 item(
-                    icon = {
-                        Icon(
-                            it.icon,
-                            contentDescription = stringResource(it.label)
-                        )
-                    },
-                    label = { Text(stringResource(it.label)) },
-                    selected = currentDestination?.route?.contains(it.direction.route) == true,
+                    icon = { Icon(item.icon, contentDescription = stringResource(item.label)) },
+                    label = { Text(stringResource(item.label)) },
+                    selected = isSelected,
                     onClick = {
-                        navigator.navigate(it.direction) {
-                            launchSingleTop = true
+                        // This will change the content of listPane
+                        currentListSection = item
+
+                        // When a new top-level section is clicked,
+                        // ensure the detail pane is reset to its empty state
+                        // if it's currently showing actual details.
+                        if (isDetailFlowActive || (currentRouteForDetailPane != EmptyDetailScreenDestination.route && currentRouteForDetailPane != null)) {
+                            // The second condition ensures reset even if isDetailFlowActive was
+                            // somehow false but detail pane isn't empty
+                            if (currentRouteForDetailPane != EmptyDetailScreenDestination.route) {
+                                destinationsNavigatorForDetail.navigate(EmptyDetailScreenDestination) {
+                                    popUpTo(NavGraphs.root.startDestination) { inclusive = true }
+                                    launchSingleTop = true
+                                }
+                            }
                         }
+                        // isDetailFlowActive will become false if we navigated to EmptyDetailScreen,
+                        // triggering listDetailNavigator to Secondary via the LaunchedEffect.
                     }
                 )
             }
-        },
-        content = {
-            AppNavigation(
-                navHostController = navController
-            )
         }
-    )
+    ) {
+        NavigableListDetailPaneScaffold(
+            modifier = Modifier.fillMaxSize(),
+            navigator = listDetailNavigator,
+            listPane = {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.surface) // Ensure opaque background
+                ) {
+                    TopAppBar(
+                        title = { Text(stringResource(currentListSection.label)) }
+                    )
+                    // Content of the current list section
+                    // IMPORTANT: Pass destinationsNavigatorForDetail for navigation to detail screens
+                    when (currentListSection) {
+                        NavigationDestination.Dashboard -> DashboardScreen(navigator = destinationsNavigatorForDetail)
+                        NavigationDestination.SearchScreen -> SearchScreen(navigator = destinationsNavigatorForDetail)
+                        NavigationDestination.Explore -> ExploreScreen(navigator = destinationsNavigatorForDetail)
+                        NavigationDestination.TraktAccount -> TraktAccountScreen(
+                            navigator = destinationsNavigatorForDetail,
+                            code = null /* Code handled by LaunchedEffect below */
+                        )
+                    }
+                }
+            },
+            detailPane = {
+                windowSizeClass?.let { windowSizeClass ->
+                    AppNavigation(
+                        navHostController = mainNavController,
+                        overrideUpNavigation = {
+                            if (showDetailScreenArgs != null) {
+                                destinationsNavigatorForDetail.navigate(EmptyDetailScreenDestination) {
+                                    popUpTo(NavGraphs.root.startDestination) { inclusive = true }
+                                    launchSingleTop = true
+                                }
+                            } else {
+                                mainNavController.popBackStack()
+                            }
+                        }
+                    )
+                }
+            }
+        )
+    }
+
+    // Trakt OAuth handling
+    LaunchedEffect(valueState.value) {
+        if (!valueState.value.isNullOrEmpty()) {
+            val codeArg = valueState.value
+            valueState.value = null
+            onTraktAuthCompleted()
+
+            currentListSection = NavigationDestination.TraktAccount // Switch list pane
+
+            destinationsNavigatorForDetail.navigate(
+                TraktAccountScreenDestination(code = codeArg)
+            ) {
+                // Clear backstack up to start, then add Empty
+                popUpTo(NavGraphs.root.startDestination) { inclusive = true; saveState = true }
+                launchSingleTop = true
+            }
+            // isDetailFlowActive will become true after navigation to TraktAccountScreen,
+            // and listDetailNavigator will switch to Primary.
+        }
+    }
 }

--- a/app/src/main/java/com/theupnextapp/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/theupnextapp/ui/navigation/AppNavigation.kt
@@ -10,11 +10,10 @@
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package com.theupnextapp.ui.navigation
-
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Surface
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
@@ -26,29 +25,54 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import com.ramcosta.composedestinations.DestinationsNavHost
 import com.ramcosta.composedestinations.generated.NavGraphs
+import com.ramcosta.composedestinations.generated.destinations.ShowDetailScreenDestination
 import com.theupnextapp.ui.main.TopBar
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 
-@ExperimentalMaterial3WindowSizeClassApi
-@ExperimentalMaterial3Api
-@ExperimentalComposeUiApi
-@ExperimentalFoundationApi
-@ExperimentalAnimationApi
+@OptIn(
+    ExperimentalCoroutinesApi::class,
+    ExperimentalMaterial3WindowSizeClassApi::class,
+    ExperimentalMaterial3Api::class,
+    ExperimentalComposeUiApi::class,
+    ExperimentalFoundationApi::class,
+    ExperimentalAnimationApi::class,
+)
 @Composable
 fun AppNavigation(
-    navHostController: NavHostController
+    navHostController: NavHostController,
+    overrideUpNavigation: (() -> Unit)? = null
 ) {
     val navBackStackEntry by navHostController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route
 
-    Surface {
-        Column {
-            TopBar(navBackStackEntry = navBackStackEntry) {
-                navHostController.navigateUp()
-            }
+    // Attempt to extract a title if ShowDetailArgs are present for ShowDetailScreen
+    val dynamicTitle = if (currentRoute == ShowDetailScreenDestination.route) {
+        navBackStackEntry?.let { ShowDetailScreenDestination.argsFrom(it).showTitle }
+    } else {
+        null
+    }
 
+    Surface(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            TopBar(
+                navBackStackEntry = navBackStackEntry,
+                onArrowClick = {
+                    if (overrideUpNavigation != null) {
+                        overrideUpNavigation()
+                    } else {
+                        navHostController.navigateUp()
+                    }
+                },
+                title = dynamicTitle,
+            )
+            // DestinationsNavHost uses the navHostController (mainNavController from MainScreen)
+            // It will display EmptyDetailScreen, ShowDetailScreen, etc., based on its current route.
             DestinationsNavHost(
                 navGraph = NavGraphs.root,
                 navController = navHostController,
-                modifier = Modifier,
+                modifier = Modifier.weight(1f) // Ensures it takes available space
             )
         }
     }

--- a/app/src/main/java/com/theupnextapp/ui/showDetail/EmptyDetailScreen.kt
+++ b/app/src/main/java/com/theupnextapp/ui/showDetail/EmptyDetailScreen.kt
@@ -1,0 +1,89 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Ahmed Tikiwa
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.theupnextapp.ui.showDetail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Movie
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass // Required for this screen
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.ramcosta.composedestinations.annotation.Destination
+import com.ramcosta.composedestinations.annotation.RootGraph
+import com.theupnextapp.R
+import androidx.activity.compose.LocalActivity
+
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class) // For calculateWindowSizeClass
+@Destination<RootGraph>(start = true)
+@Composable
+fun EmptyDetailScreen() {
+    // Get the activity to calculate window size class
+    val activity = LocalActivity.current // Use LocalActivity
+    val windowSizeClass = activity?.let { calculateWindowSizeClass(it) }
+
+    if (windowSizeClass != null && windowSizeClass.widthSizeClass != WindowWidthSizeClass.Compact) {
+        // Content for Medium and Expanded screens
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .padding(16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Movie,
+                    contentDescription = null,
+                    modifier = Modifier.padding(bottom = 16.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = stringResource(R.string.empty_detail_screen_prompt),
+                    style = MaterialTheme.typography.headlineSmall,
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "Your dashboard, search results, and explore sections will appear on the left.",
+                    style = MaterialTheme.typography.bodyLarge,
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                )
+            }
+        }
+    } else {
+        // Content for Compact screens (or if windowSizeClass is null, e.g., in some previews)
+        // This will be composed but effectively invisible, preventing the flicker.
+        Box(modifier = Modifier.fillMaxSize())
+    }
+}

--- a/app/src/main/java/com/theupnextapp/ui/traktAccount/TraktAccountScreen.kt
+++ b/app/src/main/java/com/theupnextapp/ui/traktAccount/TraktAccountScreen.kt
@@ -80,9 +80,11 @@ import com.theupnextapp.domain.ShowDetailArg
 import com.theupnextapp.domain.TraktUserListItem
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
-@ExperimentalMaterial3WindowSizeClassApi
-@ExperimentalFoundationApi
+@OptIn(
+    ExperimentalMaterial3Api::class,
+    ExperimentalMaterial3WindowSizeClassApi::class,
+    ExperimentalFoundationApi::class
+)
 @Destination<RootGraph>
 @Composable
 fun TraktAccountScreen(
@@ -229,7 +231,7 @@ private fun AccountContent(
         } else {
             if (isAuthorizedOnTrakt) {
                 TraktProfileHeader(onLogoutClick = onLogoutClick)
-                Spacer(modifier = Modifier.height(16.dp)) // Space between header and content
+                Spacer(modifier = Modifier.height(16.dp))
 
                 if (isLoadingFavorites) {
                     CircularProgressIndicator(modifier = Modifier.padding(16.dp))
@@ -237,7 +239,7 @@ private fun AccountContent(
                 } else if (isFavoriteShowsEmpty) {
                     EmptyFavoritesContent()
                 } else {
-                    FavoritesListContent( // Renamed or refactored
+                    FavoritesListContent(
                         favoriteShows = favoriteShowsList,
                         widthSizeClass = getWindowSizeClass()?.widthSizeClass,
                         onFavoriteClick = onFavoriteClick,
@@ -294,8 +296,6 @@ fun openCustomTab(context: Context) {
     val builder = CustomTabsIntent.Builder()
     builder.setShowTitle(true)
     builder.setInstantAppsEnabled(true)
-    // Optional: Add color to the custom tab toolbar
-    // builder.setToolbarColor(ContextCompat.getColor(context, R.color.your_color))
 
     val customBuilder = builder.build()
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,8 @@
     <string name="title_loading">Loading</string>
     <string name="title_unknown">Title Unknown</string>
 
+    <string name="action_navigate_up_description">Navigation arrow</string>
+
     <!-- Notification channels -->
     <string name="notification_channel_name">App Updates</string>
     <string name="notification_channel_description">Notifications for app data updates and background tasks.</string>
@@ -51,6 +53,9 @@
     <string name="nav_title_explore">Explore</string>
     <string name="nav_title_settings">Settings</string>
     <string name="nav_title_account">Account</string>
+
+    <!-- Empty detail screen -->
+    <string name="empty_detail_screen_prompt">Select a show from the list to see its details.</string>
 
     <!-- Show Detail -->
     <string name="show_detail_synopsis_heading">Synopsis</string>

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx4g
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ androidMaterial3 = "1.3.2"
 androidMaterial3Adaptive = "1.1.0"
 androidMaterial3AdaptiveNavigation = "1.3.2"
 androidRecyclerview = "1.4.0"
-androidGradlePlugin = "8.10.0"
+androidGradlePlugin = "8.10.1"
 androidxHiltNavigation = "1.2.0"
 androidxBenchmarkJunit4 = "1.3.4"
 androidxRecyclerviewSelection = "1.2.0"
@@ -40,7 +40,7 @@ hiltAndroidTesting = "2.56.2"
 hiltWork = "1.2.0"
 jsoup = "1.20.1"
 junit = "4.13.2"
-ktlint = "12.2.0"
+ktlint = "12.3.0"
 kotlin = "2.1.21"
 kotlinxCoroutinesAndroid = "1.10.2"
 kotlinxCoroutinesTest = "1.10.2"
@@ -51,7 +51,7 @@ legacySupportV4 = "1.0.0"
 lifecycleViewmodelCompose = "2.9.0"
 mockitoCore = "5.18.0"
 mockitoKotlin = "5.4.0"
-okhttp = "5.0.0-alpha.14"
+okhttp = "5.0.0-alpha.15"
 materialIconsExtended = "1.7.8"
 moshi = "1.15.2"
 pagingRuntimeKtx = "3.3.6"
@@ -73,11 +73,14 @@ accompanist-swiperefresh = { module = "com.google.accompanist:accompanist-swiper
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
 android-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "ktx" }
 android-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "androidxHiltNavigation" }
+androidx-adaptive-navigation-android = { group = "androidx.compose.material3.adaptive", name = "adaptive-navigation-android", version.ref = "androidMaterial3Adaptive" }
 android-hilt-work = { module = "androidx.hilt:hilt-work", version.ref = "hiltWork" }
 android-hilt-work-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hiltCompiler" }
 android-material = { group = "com.google.android.material", name = "material", version.ref = "androidMaterial" }
 android-material3 = { module = "androidx.compose.material3:material3", version.ref = "androidMaterial3" }
+android-material3-adaptive = { module = "androidx.compose.material3.adaptive:adaptive", version.ref = "androidMaterial3Adaptive" }
 android-material3-adaptive-layout = { module = "androidx.compose.material3.adaptive:adaptive-layout", version.ref = "androidMaterial3Adaptive" }
+android-material3-adaptive-navigation = { module = "androidx.compose.material3.adaptive:adaptive-navigation", version.ref = "androidMaterial3Adaptive" }
 android-material3-adaptive-navigation-suite = { module = "androidx.compose.material3:material3-adaptive-navigation-suite", version.ref = "androidMaterial3AdaptiveNavigation" }
 android-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "androidRecyclerview" }
 androidx-benchmark-macrobenchmark-junit4 = { module = "androidx.benchmark:benchmark-macro-junit4", version.ref = "androidxBenchmarkJunit4" }


### PR DESCRIPTION
Documentation reference: https://developer.android.com/develop/ui/compose/layouts/adaptive/list-detail

### Medium / Expanded Window Size Class

| With no show selected from listPane | With a show selected in the listPane |
| ------------- | ------------ | 
| ![Screenshot_20250531_122410](https://github.com/user-attachments/assets/613f1b7f-43b5-444f-a04a-65c60f91564b) | ![Screenshot_20250531_122148](https://github.com/user-attachments/assets/67123434-7075-48fe-89f2-8902de0dc32e) |

| Search screen |
| ---- |
| ![Screenshot_20250531_143819](https://github.com/user-attachments/assets/a6aceace-0b13-4804-8079-282df18d7991) | 



`AppNavigation.kt`

   Refactor: Enhance `AppNavigation` for Dynamic Show Titles

   This commit modifies the `AppNavigation` composable to dynamically display the show title in the `TopBar` when navigating to the `ShowDetailScreen`.

Key changes:
- Updated `AppNavigation` to accept an optional `overrideUpNavigation` lambda for custom back navigation handling.
- Extracted the current route and attempted to retrieve `showTitle` from `ShowDetailScreenDestination` arguments.
- Passed the retrieved `dynamicTitle` to the `TopBar`.
- Ensured `Surface` and `Column` fill the maximum size.
- Made `DestinationsNavHost` take up the remaining available space using `Modifier.weight(1f)`.
- Applied necessary opt-in annotations.

----

`MainScreen.kt`
Refactor: Implement adaptive layout in `MainScreen`

This commit introduces an adaptive layout to `MainScreen` using `NavigableListDetailPaneScaffold` to provide a list/detail experience.

Key changes:
- `MainScreen` now utilizes `NavigableListDetailPaneScaffold` for adaptive layouts.
- Introduces `currentListSection` state to manage the active top-level navigation item.
- Handles navigation between list and detail panes based on window size and content.
- Implements custom back handling for adaptive layouts, allowing navigation within the detail pane or back from the detail pane to the list.
- Ensures the detail pane resets to an empty state when switching top-level list sections.
- Refactors Trakt OAuth handling to correctly navigate and update the UI in the adaptive layout.
- `AppNavigation` is now used for the detail pane content.
- Top-level list sections (Dashboard, Search, Explore, Trakt Account) are displayed in the list pane.
- The `Up` button in the detail pane now navigates back to the empty detail state or pops the back stack appropriately.

---

`TopBar.kt`

Refactor: Improve TopBar behavior and title handling

This commit refactors the `TopBar` composable to:

- Conditionally display the back arrow based on the current navigation destination, ensuring it only appears on child screens like show details, seasons, and episodes.
- Allow a custom title to be passed, prioritizing it over the default title derived from the current route.
- Use `Icons.AutoMirrored.Filled.ArrowBack` for automatic mirroring in RTL layouts.
- Remove the `AnimatedVisibility` for the app bar title and navigation icon, simplifying the logic.
- Remove the `isChildScreen` function as its logic is now integrated into the `TopBar`.
- Add a `modifier` parameter to the `TopBar`.
- Add a `scrollBehavior` parameter to the `TopBar`.

---

`ShowDetailScreen`

Refactor: Use Scaffold in ShowDetailScreen

This commit introduces the `Scaffold` composable to the `ShowDetailScreen`.

Key changes:
- Integrated `Scaffold` to manage the layout, allowing for a dedicated `SnackbarHost`.
- The `SnackbarHost` is now placed within the `Scaffold`, using the remembered `snackbarHostState`.
- Removed redundant Box and Column structures as `Scaffold` provides a content area.
- Simplified `EpisodePlaceholder` by removing the unused `type` parameter.
- Minor cleanup of comments and unused code.
- Optimized imports.

Closes #406 
