### PR TITLE
Fix: Implement and test Room migration 29-30

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,8 +49,8 @@ android {
         applicationId "com.theupnextapp"
         minSdkVersion 24
         targetSdkVersion 36
-        versionCode 208
-        versionName "3.10.1"
+        versionCode 209
+        versionName "3.10.2"
         testInstrumentationRunner "com.theupnextapp.CustomTestRunner"
 
         ksp {
@@ -264,6 +264,7 @@ dependencies {
     androidTestImplementation libs.androidx.test.ext.junit
     androidTestImplementation libs.androidx.ui.test.junit4
     androidTestImplementation libs.androidx.test.runner
+    androidTestImplementation libs.room.testing
 
     // Mockito for mocking dependencies (highly recommended)
     testImplementation libs.mockito.core

--- a/app/src/androidTest/java/com/theupnextapp/database/MigrationTest.kt
+++ b/app/src/androidTest/java/com/theupnextapp/database/MigrationTest.kt
@@ -1,0 +1,33 @@
+package com.theupnextapp.database
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+
+private const val TEST_DB_NAME = "migration-test"
+
+@RunWith(AndroidJUnit4::class)
+class MigrationTest {
+
+    @get:Rule
+    val helper: MigrationTestHelper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        UpnextDatabase::class.java,
+        emptyList(),
+        FrameworkSQLiteOpenHelperFactory()
+    )
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate29To30() {
+        helper.createDatabase(TEST_DB_NAME, 29).close()
+
+        // Re-open the database with version 30 and the migration.
+        helper.runMigrationsAndValidate(TEST_DB_NAME, 30, true, MIGRATION_29_30).close()
+    }
+}

--- a/app/src/main/java/com/theupnextapp/database/Migrations.kt
+++ b/app/src/main/java/com/theupnextapp/database/Migrations.kt
@@ -4,7 +4,10 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
 val MIGRATION_29_30 = object : Migration(29, 30) {
-    override fun migrate(database: SupportSQLiteDatabase) {
-        // Do nothing
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("CREATE TABLE `schedule_yesterday_new` (`id` INTEGER NOT NULL, `showId` INTEGER, `image` TEXT, `mediumImage` TEXT, `language` TEXT, `name` TEXT, `officialSite` TEXT, `premiered` TEXT, `runtime` TEXT, `status` TEXT, `summary` TEXT, `type` TEXT, `updated` TEXT, `url` TEXT, PRIMARY KEY(`id`))")
+        db.execSQL("INSERT INTO `schedule_yesterday_new` (`id`, `showId`, `image`, `mediumImage`, `language`, `name`, `officialSite`, `premiered`, `runtime`, `status`, `summary`, `type`, `updated`, `url`) SELECT `id`, `showId`, `image`, `mediumImage`, `language`, `name`, `officialSite`, `premiered`, `runtime`, `status`, `summary`, `type`, `updated`, `url` FROM `schedule_yesterday`")
+        db.execSQL("DROP TABLE `schedule_yesterday`")
+        db.execSQL("ALTER TABLE `schedule_yesterday_new` RENAME TO `schedule_yesterday`")
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -144,6 +144,7 @@ retrofit2-kotlin-coroutines-adapter = { module = "com.jakewharton.retrofit:retro
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
 room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
+room-testing = { module = "androidx.room:room-testing", version.ref = "room" }
 runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata", version.ref = "runtimeLivedata" }
 moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }


### PR DESCRIPTION
- Implemented Room database migration from version 29 to 30, which recreates the `schedule_yesterday` table.
- Added `room-testing` dependency.
- Added `MigrationTest` to validate the migration from version 29 to 30.
- Bumped app version to 3.10.2.