### PR TITLE
chore(benchmark): enhance macrobenchmarks with account tab journey and TMDB image fetch tracing

### DIFF
--- a/baselineprofile/src/main/java/com/theupnextapp/baselineprofile/BaselineProfileGenerator.kt
+++ b/baselineprofile/src/main/java/com/theupnextapp/baselineprofile/BaselineProfileGenerator.kt
@@ -70,6 +70,8 @@ class BaselineProfileGenerator {
 
             goToShowDetailJourney()
 
+            accountScreenJourney()
+
             // Check UiAutomator documentation for more information how to interact with the app.
             // https://d.android.com/training/testing/other-components/ui-automator
         }
@@ -96,4 +98,11 @@ fun MacrobenchmarkScope.goToShowDetailJourney() {
     val index = (iteration ?: 0) % showItems.size
     showItems[index].click()
     device.wait(Until.gone(By.res("dashboard_list")), 5_000)
+}
+
+fun MacrobenchmarkScope.accountScreenJourney() {
+    device.wait(Until.hasObject(By.text("Account")), 10_000)
+    device.findObject(By.text("Account"))?.click()
+    device.wait(Until.hasObject(By.text("Connect to Trakt")), 10_000)
+    device.waitForIdle()
 }

--- a/baselineprofile/src/main/java/com/theupnextapp/baselineprofile/ScrollBenchmarks.kt
+++ b/baselineprofile/src/main/java/com/theupnextapp/baselineprofile/ScrollBenchmarks.kt
@@ -13,8 +13,10 @@
 package com.theupnextapp.baselineprofile
 
 import androidx.benchmark.macro.CompilationMode
+import androidx.benchmark.macro.ExperimentalMetricApi
 import androidx.benchmark.macro.FrameTimingMetric
 import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.TraceSectionMetric
 import androidx.benchmark.macro.junit4.MacrobenchmarkRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
@@ -22,6 +24,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@OptIn(ExperimentalMetricApi::class)
 @LargeTest
 @RunWith(AndroidJUnit4::class)
 class ScrollBenchmarks {
@@ -38,7 +41,7 @@ class ScrollBenchmarks {
     private fun scroll(compilationMode: CompilationMode) {
         rule.measureRepeated(
             packageName = "com.theupnextapp",
-            metrics = listOf(FrameTimingMetric()),
+            metrics = listOf(FrameTimingMetric(), TraceSectionMetric("TMDBImageFetch")),
             compilationMode = compilationMode,
             iterations = 10,
             startupMode = StartupMode.WARM,


### PR DESCRIPTION
### Summary
This PR enhances the macrobenchmark suite to expand coverage for critical user journeys and measure the performance of concurrent operations. It focuses on profile generation for the watchlist screens and tracing network image fetches during list scrolling.

### Key Changes
* **Account Screen Baseline Profile Generation**: Added `accountScreenJourney()` to the `BaselineProfileGenerator` rules. This navigates to the Account tab and waits for the "Connect to Trakt"/authorized state, ensuring classes related to watchlist fetching and profile loading are precompiled.
* **TraceSectionMetric in ScrollBenchmarks**: Registered `TraceSectionMetric("TMDBImageFetch")` in `ScrollBenchmarks` to measure the execution timing and thread utilization of TMDB image loading calls during dashboard/list scrolling.

### Verification
* Verified baseline profile module compilation and assembly locally:
  ```bash
  ./gradlew :baselineprofile:assemble