### PR TITLE
fix(network): add lenient GzipDecompressionInterceptor to handle TMDB trailing gzip bytes gracefully

### DIFF
--- a/core/data/src/main/java/com/theupnextapp/di/NetworkModule.kt
+++ b/core/data/src/main/java/com/theupnextapp/di/NetworkModule.kt
@@ -47,10 +47,15 @@ import okhttp3.Cache
 import okhttp3.ConnectionPool
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.asResponseBody
 import okhttp3.logging.HttpLoggingInterceptor
+import okio.buffer
+import okio.source
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import java.util.concurrent.TimeUnit
+import java.util.zip.GZIPInputStream
 import javax.inject.Singleton
 
 @Module
@@ -70,18 +75,6 @@ object NetworkModule {
         return OkHttpClient().newBuilder()
             .cache(Cache(context.cacheDir, CACHE_SIZE_BYTES))
             .addInterceptor(
-                HttpLoggingInterceptor().apply {
-                    level = HttpLoggingInterceptor.Level.BODY
-                },
-            )
-            .addInterceptor { chain ->
-                var request = chain.request()
-                request =
-                    request.newBuilder().header("Cache-Control", "public, max-age=$CACHE_MAX_AGE_SECONDS")
-                        .build()
-                chain.proceed(request)
-            }
-            .addInterceptor(
                 ChuckerInterceptor.Builder(context)
                     .collector(
                         ChuckerCollector(
@@ -96,6 +89,23 @@ object NetworkModule {
                     .createShortcut(true)
                     .build(),
             )
+            .addInterceptor { chain ->
+                var request = chain.request()
+                request =
+                    request.newBuilder().header("Cache-Control", "public, max-age=$CACHE_MAX_AGE_SECONDS")
+                        .build()
+                chain.proceed(request)
+            }
+            .addInterceptor(
+                HttpLoggingInterceptor().apply {
+                    level = if (com.theupnextapp.core.data.BuildConfig.DEBUG) {
+                        HttpLoggingInterceptor.Level.BODY
+                    } else {
+                        HttpLoggingInterceptor.Level.NONE
+                    }
+                },
+            )
+            .addNetworkInterceptor(GzipDecompressionInterceptor())
             .connectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
             .retryOnConnectionFailure(true)
             .readTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
@@ -175,5 +185,31 @@ object NetworkModule {
             .addCallAdapterFactory(CoroutineCallAdapterFactory())
             .build()
             .create(TmdbService::class.java)
+    }
+}
+
+class GzipDecompressionInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val response = chain.proceed(chain.request())
+        val body = response.body
+        if ("gzip".equals(response.header("Content-Encoding"), ignoreCase = true)) {
+            val gzipInputStream = try {
+                GZIPInputStream(body.source().inputStream())
+            } catch (e: Exception) {
+                return response
+            }
+
+            val decompressedSource = gzipInputStream.source().buffer()
+            val newHeaders = response.headers.newBuilder()
+                .removeAll("Content-Encoding")
+                .removeAll("Content-Length")
+                .build()
+
+            return response.newBuilder()
+                .headers(newHeaders)
+                .body(decompressedSource.asResponseBody(body.contentType(), -1))
+                .build()
+        }
+        return response
     }
 }

--- a/core/data/src/test/java/com/theupnextapp/common/utils/GzipDecompressionInterceptorTest.kt
+++ b/core/data/src/test/java/com/theupnextapp/common/utils/GzipDecompressionInterceptorTest.kt
@@ -1,0 +1,149 @@
+package com.theupnextapp.common.utils
+
+import com.theupnextapp.di.GzipDecompressionInterceptor
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import java.io.ByteArrayOutputStream
+import java.util.zip.GZIPOutputStream
+
+class GzipDecompressionInterceptorTest {
+
+    @Mock
+    private lateinit var mockChain: Interceptor.Chain
+
+    private lateinit var interceptor: GzipDecompressionInterceptor
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        interceptor = GzipDecompressionInterceptor()
+    }
+
+    @Test
+    fun `test interceptor decompresses gzipped response and removes headers`() {
+        // Arrange
+        val originalText = "Hello, world! This is a decompressed response."
+        
+        // Gzip the text
+        val bos = ByteArrayOutputStream()
+        GZIPOutputStream(bos).use { gzos ->
+            gzos.write(originalText.toByteArray())
+        }
+        val gzippedBytes = bos.toByteArray()
+
+        val request = Request.Builder()
+            .url("https://api.example.com/data")
+            .build()
+
+        val body = gzippedBytes.toResponseBody("application/json".toMediaType())
+        val mockResponse = Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .header("Content-Encoding", "gzip")
+            .header("Content-Length", gzippedBytes.size.toString())
+            .body(body)
+            .build()
+
+        `when`(mockChain.request()).thenReturn(request)
+        `when`(mockChain.proceed(org.mockito.kotlin.any())).thenReturn(mockResponse)
+
+        // Act
+        val response = interceptor.intercept(mockChain)
+
+        // Assert
+        assertNotNull(response)
+        assertEquals(null, response.header("Content-Encoding"))
+        assertEquals(null, response.header("Content-Length"))
+        
+        val responseBodyString = response.body.string()
+        assertEquals(originalText, responseBodyString)
+    }
+
+    @Test
+    fun `test interceptor handles trailing bytes in gzipped response gracefully`() {
+        // Arrange
+        val originalText = "Lenient Gzip Decompression works!"
+        
+        // Gzip the text
+        val bos = ByteArrayOutputStream()
+        GZIPOutputStream(bos).use { gzos ->
+            gzos.write(originalText.toByteArray())
+        }
+        // Append trailing newline bytes (this would normally fail Okio's GzipSource.read check)
+        val gzippedBytes = bos.toByteArray() + "\n\n".toByteArray()
+
+        val request = Request.Builder()
+            .url("https://api.example.com/data")
+            .build()
+
+        val body = gzippedBytes.toResponseBody("application/json".toMediaType())
+        val mockResponse = Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .header("Content-Encoding", "gzip")
+            .header("Content-Length", gzippedBytes.size.toString())
+            .body(body)
+            .build()
+
+        `when`(mockChain.request()).thenReturn(request)
+        `when`(mockChain.proceed(org.mockito.kotlin.any())).thenReturn(mockResponse)
+
+        // Act
+        val response = interceptor.intercept(mockChain)
+
+        // Assert
+        assertNotNull(response)
+        assertEquals(null, response.header("Content-Encoding"))
+        
+        val responseBodyString = response.body.string()
+        assertEquals(originalText, responseBodyString)
+    }
+
+    @Test
+    fun `test interceptor passes non-gzipped response unmodified`() {
+        // Arrange
+        val originalText = "Plain text response."
+        val request = Request.Builder()
+            .url("https://api.example.com/data")
+            .build()
+
+        val body = originalText.toResponseBody("text/plain".toMediaType())
+        val mockResponse = Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .header("Content-Type", "text/plain")
+            .body(body)
+            .build()
+
+        `when`(mockChain.request()).thenReturn(request)
+        `when`(mockChain.proceed(org.mockito.kotlin.any())).thenReturn(mockResponse)
+
+        // Act
+        val response = interceptor.intercept(mockChain)
+
+        // Assert
+        assertNotNull(response)
+        assertEquals("text/plain", response.header("Content-Type"))
+        assertEquals(null, response.header("Content-Encoding"))
+        
+        val responseBodyString = response.body.string()
+        assertEquals(originalText, responseBodyString)
+    }
+}


### PR DESCRIPTION

---

### Lenient GZIP Decompression Fix

#### **Description**

### Summary
This PR resolves an obscure crash where certain TMDB API responses failed decompression. The issue is caused by TMDB occasionally appending trailing whitespace or newlines at the end of their GZIP payload. Because OkHttp's built-in decompressor uses Okio's strict `GzipSource`, buffering these trailing bytes throws `gzip finished without exhausting source`, crashing downstream loggers or converters.

### Key Changes
* **Lenient Network Interceptor**: Created `GzipDecompressionInterceptor` and registered it as a **Network Interceptor** (`addNetworkInterceptor`). Running before OkHttp's `BridgeInterceptor` allows it to process raw compressed bodies.
* **Lenient Decompression Logic**: Uses Java's native `GZIPInputStream` (which leniently ignores trailing stream bytes/newlines) to decompress the body. It strips the `Content-Encoding: gzip` and `Content-Length` headers, passing a clean uncompressed stream upstream.
* **Security Hardening**: Hardened `HttpLoggingInterceptor` registration to only output the full `BODY` level in `DEBUG` builds to prevent logging sensitive user tokens in production.

### Verification
* Added comprehensive unit tests in `GzipDecompressionInterceptorTest` covering:
  - Standard GZIP stream decompression.
  - Lenient handling of trailing bytes/newlines (verifying no crashes are thrown).
  - Unmodified forwarding of non-gzipped payloads.
* All tests compiled and passed:
  ```bash
  ./gradlew :core:data:testDebugUnitTest --tests "com.theupnextapp.common.utils.GzipDecompressionInterceptorTest"